### PR TITLE
Add image insertion functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This comprehensive server uses the Model Context Protocol (MCP) and the `fastmcp
 ### Document Structure
 - **Tables:** Create tables with `insertTable`
 - **Page Breaks:** Insert page breaks with `insertPageBreak`
+- **Images:** Insert images from URLs with `insertImageFromUrl`, or upload local images with `insertLocalImage`
 - **Experimental Features:** Tools like `fixListFormatting` for automatic list detection
 
 ### 🆕 Comment Management
@@ -215,11 +216,59 @@ Once configured, you should be able to use the tools in your chats with Claude:
 - **Text Styling**: "Use `applyTextStyle` to make the text 'Important Section' bold and red (#FF0000) in document `YOUR_GOOGLE_DOC_ID`."
 - **Paragraph Styling**: "Use `applyParagraphStyle` to center-align the paragraph containing 'Title Here' in document `YOUR_GOOGLE_DOC_ID`."
 - **Table Creation**: "Insert a 3x4 table at index 500 in document `YOUR_GOOGLE_DOC_ID` using the `insertTable` tool."
+- **Image Insertion**: "Use `insertImageFromUrl` to insert an image from 'https://example.com/image.png' at index 100 in document `YOUR_GOOGLE_DOC_ID`."
+- **Local Image Upload**: "Use `insertLocalImage` to upload '/path/to/image.jpg' and insert it at index 200 in document `YOUR_GOOGLE_DOC_ID`."
 - **Legacy Formatting**: "Use `formatMatchingText` to find the second instance of 'Project Alpha' and make it blue (#0000FF) in doc `YOUR_GOOGLE_DOC_ID`."
 
 Remember to replace `YOUR_GOOGLE_DOC_ID` with the actual ID from a Google Doc's URL (the long string between `/d/` and `/edit`).
 
 Claude will automatically launch your server in the background when needed using the command you provided. You do **not** need to run `node ./dist/server.js` manually anymore.
+
+---
+
+## Image Insertion
+
+This server provides two ways to insert images into Google Documents:
+
+### 1. Insert from Public URL (`insertImageFromUrl`)
+
+Inserts an image directly from a publicly accessible URL. The image URL must be accessible without authentication.
+
+**Parameters:**
+- `documentId`: The Google Document ID
+- `imageUrl`: Publicly accessible URL (http:// or https://)
+- `index`: Position in the document (1-based indexing)
+- `width` (optional): Image width in points
+- `height` (optional): Image height in points
+
+**Example:**
+```
+"Insert an image from https://example.com/logo.png at index 100 in document YOUR_DOC_ID"
+```
+
+### 2. Upload Local Image (`insertLocalImage`)
+
+Uploads a local image file to Google Drive and inserts it into the document. This is a two-step process that:
+1. Uploads the image to Google Drive (by default to the same folder as the document)
+2. Makes the image publicly readable
+3. Inserts the image into the document using its Drive URL
+
+**Parameters:**
+- `documentId`: The Google Document ID
+- `localImagePath`: Absolute path to the local image file
+- `index`: Position in the document (1-based indexing)
+- `width` (optional): Image width in points
+- `height` (optional): Image height in points
+- `uploadToSameFolder` (optional, default: true): If true, uploads to the document's folder; if false, uploads to Drive root
+
+**Supported formats:** .jpg, .jpeg, .png, .gif, .bmp, .webp, .svg
+
+**Example:**
+```
+"Upload and insert the image at /Users/myname/Pictures/chart.png at index 200 in document YOUR_DOC_ID with width 400 and height 300"
+```
+
+**Note:** The uploaded image will be made publicly readable so it can be displayed in the document. The image file will remain in your Google Drive and can be managed separately.
 
 ---
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -709,6 +709,111 @@ throw new UserError(`Failed to insert page break: ${error.message || 'Unknown er
 }
 });
 
+// --- Image Insertion Tools ---
+
+server.addTool({
+name: 'insertImageFromUrl',
+description: 'Inserts an inline image into a Google Document from a publicly accessible URL.',
+parameters: DocumentIdParameter.extend({
+imageUrl: z.string().url().describe('Publicly accessible URL to the image (must be http:// or https://).'),
+index: z.number().int().min(1).describe('The index (1-based) where the image should be inserted.'),
+width: z.number().min(1).optional().describe('Optional: Width of the image in points.'),
+height: z.number().min(1).optional().describe('Optional: Height of the image in points.'),
+}),
+execute: async (args, { log }) => {
+const docs = await getDocsClient();
+log.info(`Inserting image from URL ${args.imageUrl} at index ${args.index} in doc ${args.documentId}`);
+
+try {
+await GDocsHelpers.insertInlineImage(
+docs,
+args.documentId,
+args.imageUrl,
+args.index,
+args.width,
+args.height
+);
+
+let sizeInfo = '';
+if (args.width && args.height) {
+sizeInfo = ` with size ${args.width}x${args.height}pt`;
+}
+
+return `Successfully inserted image from URL at index ${args.index}${sizeInfo}.`;
+} catch (error: any) {
+log.error(`Error inserting image in doc ${args.documentId}: ${error.message || error}`);
+if (error instanceof UserError) throw error;
+throw new UserError(`Failed to insert image: ${error.message || 'Unknown error'}`);
+}
+}
+});
+
+server.addTool({
+name: 'insertLocalImage',
+description: 'Uploads a local image file to Google Drive and inserts it into a Google Document. The image will be uploaded to the same folder as the document (or optionally to a specified folder).',
+parameters: DocumentIdParameter.extend({
+localImagePath: z.string().describe('Absolute path to the local image file (supports .jpg, .jpeg, .png, .gif, .bmp, .webp, .svg).'),
+index: z.number().int().min(1).describe('The index (1-based) where the image should be inserted in the document.'),
+width: z.number().min(1).optional().describe('Optional: Width of the image in points.'),
+height: z.number().min(1).optional().describe('Optional: Height of the image in points.'),
+uploadToSameFolder: z.boolean().optional().default(true).describe('If true, uploads the image to the same folder as the document. If false, uploads to Drive root.'),
+}),
+execute: async (args, { log }) => {
+const docs = await getDocsClient();
+const drive = await getDriveClient();
+log.info(`Uploading local image ${args.localImagePath} and inserting at index ${args.index} in doc ${args.documentId}`);
+
+try {
+// Get the document's parent folder if requested
+let parentFolderId: string | undefined;
+if (args.uploadToSameFolder) {
+try {
+const docInfo = await drive.files.get({
+fileId: args.documentId,
+fields: 'parents'
+});
+if (docInfo.data.parents && docInfo.data.parents.length > 0) {
+parentFolderId = docInfo.data.parents[0];
+log.info(`Will upload image to document's parent folder: ${parentFolderId}`);
+}
+} catch (folderError) {
+log.warn(`Could not determine document's parent folder, using Drive root: ${folderError}`);
+}
+}
+
+// Upload the image to Drive
+log.info(`Uploading image to Drive...`);
+const imageUrl = await GDocsHelpers.uploadImageToDrive(
+drive,
+args.localImagePath,
+parentFolderId
+);
+log.info(`Image uploaded successfully, public URL: ${imageUrl}`);
+
+// Insert the image into the document
+await GDocsHelpers.insertInlineImage(
+docs,
+args.documentId,
+imageUrl,
+args.index,
+args.width,
+args.height
+);
+
+let sizeInfo = '';
+if (args.width && args.height) {
+sizeInfo = ` with size ${args.width}x${args.height}pt`;
+}
+
+return `Successfully uploaded image to Drive and inserted it at index ${args.index}${sizeInfo}.\nImage URL: ${imageUrl}`;
+} catch (error: any) {
+log.error(`Error uploading/inserting local image in doc ${args.documentId}: ${error.message || error}`);
+if (error instanceof UserError) throw error;
+throw new UserError(`Failed to upload/insert local image: ${error.message || 'Unknown error'}`);
+}
+}
+});
+
 // --- Intelligent Assistance Tools (Examples/Stubs) ---
 
 server.addTool({


### PR DESCRIPTION
# Add Image Insertion Functionality

This PR adds comprehensive image insertion capabilities to the Google Docs MCP server, enabling users to insert images into documents either from public URLs or by uploading local files.

## 🎯 Features Added

### Two New MCP Tools

1. **`insertImageFromUrl`** - Insert images from publicly accessible URLs
   - Direct insertion from any public HTTP/HTTPS image URL
   - Optional width/height customization (in points)
   - Validates URL format before insertion
   
2. **`insertLocalImage`** - Upload local images and insert them
   - Uploads image to Google Drive (same folder as document by default)
   - Makes image publicly readable for document display
   - Supports multiple formats: .jpg, .jpeg, .png, .gif, .bmp, .webp, .svg
   - Returns Drive URL for reference

## 🛠️ Implementation Details

### Helper Functions (src/googleDocsApiHelpers.ts)

- **`insertInlineImage()`**: Core image insertion logic
  - Uses Google Docs API `insertInlineImage` request
  - Handles optional sizing parameters
  - Proper error handling and validation

- **`uploadImageToDrive()`**: Local file upload handler
  - Auto-detects MIME type from file extension
  - Creates public read permissions
  - Returns webContentLink for insertion

### Tool Integration (src/server.ts)

Both tools follow existing patterns:
- Use `DocumentIdParameter` schema
- Proper error handling with `UserError`
- Comprehensive logging
- Parameter validation with Zod schemas

## 📚 Documentation

Updated README.md with:
- New "Images" section in Document Structure
- Detailed "Image Insertion" section with usage examples
- Parameter descriptions for both tools
- Security note about public image permissions
- Advanced usage examples

## ✅ Testing

- ✅ TypeScript compilation successful
- ✅ Server starts without errors
- ✅ Tools properly registered with MCP
- ✅ Follows existing codebase patterns
- ✅ No breaking changes to existing functionality

## 💡 Usage Examples

**From URL:**
```
"Insert an image from https://example.com/logo.png at index 100 in document YOUR_DOC_ID with width 300 and height 200"
```

**Local file:**
```
"Upload and insert the image at /Users/myname/Pictures/chart.png at index 200 in document YOUR_DOC_ID"
```

## 🔒 Security Considerations

- Images uploaded via `insertLocalImage` are made publicly readable (required for Google Docs to display them)
- Images remain in user's Google Drive and can be managed separately
- Uses existing OAuth scopes (no new permissions required)

## 📝 Notes

- The Google Docs API requires images to be publicly accessible URLs
- `insertLocalImage` handles the workflow automatically: upload → make public → insert
- Default behavior uploads to same folder as target document for better organization

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>