### PR TITLE
Fix addComment tool by adding required fields parameter

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -991,6 +991,7 @@ server.addTool({
       
       const response = await drive.comments.create({
         fileId: args.documentId,
+        fields: 'id,content,quotedFileContent,author,createdTime,resolved',
         requestBody: {
           content: args.commentText,
           quotedFileContent: {


### PR DESCRIPTION
Resolves issue #16 where the addComment tool was failing with error "The 'fields' parameter is required for this method."

The Google Drive API v3 requires the 'fields' parameter for comments.create() calls to specify which fields should be returned in the response. This was missing from the implementation, causing all addComment operations to fail.

Added fields parameter with the same field set used in other comment-related operations (listComments, getComment) for consistency:
- id
- content
- quotedFileContent
- author
- createdTime
- resolved

This brings addComment in line with replyToComment and other API operations which already include the required fields parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)