### PR TITLE
fix: resolve API errors in getDocumentInfo and applyParagraphStyle

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1566,7 +1566,9 @@ log.info(`Getting info for document: ${args.documentId}`);
 try {
   const response = await drive.files.get({
     fileId: args.documentId,
-    fields: 'id,name,description,mimeType,size,createdTime,modifiedTime,webViewLink,alternateLink,owners(displayName,emailAddress),lastModifyingUser(displayName,emailAddress),shared,permissions(role,type,emailAddress),parents,version',
+    // Note: 'permissions' and 'alternateLink' fields removed - they cause
+    // "Invalid field selection" errors for Google Docs files
+    fields: 'id,name,description,mimeType,size,createdTime,modifiedTime,webViewLink,owners(displayName,emailAddress),lastModifyingUser(displayName,emailAddress),shared,parents,version',
   });
 
   const file = response.data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,7 @@ linkUrl: z.string().url().optional().describe('Make the text a hyperlink pointin
 export type TextStyleArgs = z.infer<typeof TextStyleParameters>;
 
 export const ParagraphStyleParameters = z.object({
-alignment: z.enum(['LEFT', 'CENTER', 'RIGHT', 'JUSTIFIED']).optional().describe('Paragraph alignment.'),
+alignment: z.enum(['START', 'END', 'CENTER', 'JUSTIFIED']).optional().describe('Paragraph alignment. START=left for LTR languages, END=right for LTR languages.'),
 indentStart: z.number().min(0).optional().describe('Left indentation in points.'),
 indentEnd: z.number().min(0).optional().describe('Right indentation in points.'),
 spaceAbove: z.number().min(0).optional().describe('Space before the paragraph in points.'),
@@ -113,9 +113,7 @@ export const ApplyParagraphStyleToolParameters = DocumentIdParameter.extend({
 // Target EITHER by range OR by finding text (tool logic needs to find paragraph boundaries)
 target: z.union([
 RangeParameters, // User provides paragraph start/end (less likely)
-TextFindParameter.extend({
-applyToContainingParagraph: z.literal(true).default(true).describe("Must be true. Indicates the style applies to the whole paragraph containing the found text.")
-}),
+TextFindParameter, // Find text within paragraph to apply style
 z.object({ // Target by specific index within the paragraph
 indexWithinParagraph: z.number().int().min(1).describe("An index located anywhere within the target paragraph.")
 })


### PR DESCRIPTION
## Summary
Fixes critical API errors that prevented `getDocumentInfo` and `applyParagraphStyle` tools from working correctly with Google Docs files.

## Changes

### getDocumentInfo
- **Fixed:** Remove `permissions` and `alternateLink` fields from Drive API request
- **Reason:** These fields cause "Invalid field selection" errors for Google Docs files
- **Impact:** Tool now reliably returns document metadata without errors

### applyParagraphStyle
- **Fixed:** Change alignment enum from `LEFT/RIGHT` to `START/END` 
- **Reason:** Google Docs API requires START/END per internationalization standards
  - `START` = left for LTR languages, right for RTL languages
  - `END` = right for LTR languages, left for RTL languages
- **Impact:** Prevents "Invalid value for ParagraphStyle.alignment" errors

- **Simplified:** Remove redundant `applyToContainingParagraph` field from target parameter
- **Reason:** Field was always `true` and served no purpose
- **Impact:** Cleaner parameter schema, same functionality

## Testing
- ✅ Built successfully with TypeScript
- ✅ Verified `getDocumentInfo` returns metadata without errors
- ✅ Verified `applyParagraphStyle` accepts START/END alignment values
- ✅ No linter errors

## Breaking Changes
⚠️ **Minor:** Users of `applyParagraphStyle` must use `START`/`END` instead of `LEFT`/`RIGHT` for alignment. Note that the old values caused API errors anyway, so this is effectively a bug fix rather than a breaking change.
