### PR TITLE
Improve markdown fidelity in appendMarkdownToGoogleDoc

### DIFF
--- a/src/markdownToGoogleDocs.ts
+++ b/src/markdownToGoogleDocs.ts
@@ -18,6 +18,7 @@ interface FormattingState {
   italic?: boolean;
   strikethrough?: boolean;
   link?: string;
+  code?: boolean;
 }
 
 interface ParagraphRange {
@@ -29,15 +30,14 @@ interface ParagraphRange {
 interface ListState {
   type: 'bullet' | 'ordered';
   level: number;
-  listId?: string;
 }
 
 interface PendingListItem {
   startIndex: number;
   endIndex?: number;
-  listId: string;
   nestingLevel: number;
-  isOrdered: boolean;
+  bulletPreset: 'NUMBERED_DECIMAL_ALPHA_ROMAN' | 'BULLET_DISC_CIRCLE_SQUARE' | 'BULLET_CHECKBOX';
+  taskPrefixProcessed: boolean;
 }
 
 interface ConversionContext {
@@ -49,11 +49,15 @@ interface ConversionContext {
   listStack: ListState[];
   paragraphRanges: ParagraphRange[];
   pendingListItems: PendingListItem[];
-  listIds: Map<string, string>; // Maps list type+level to listId
+  openListItemStack: number[];
   tabId?: string;
   currentParagraphStart?: number;
   currentHeadingLevel?: number;
 }
+
+const CODE_FONT_FAMILY = 'Roboto Mono';
+const CODE_TEXT_HEX = '#188038';
+const CODE_BACKGROUND_HEX = '#F1F3F4';
 
 // --- Main Conversion Function ---
 
@@ -85,7 +89,7 @@ export function convertMarkdownToRequests(
     listStack: [],
     paragraphRanges: [],
     pendingListItems: [],
-    listIds: new Map(),
+    openListItemStack: [],
     tabId
   };
 
@@ -132,8 +136,10 @@ function processToken(token: Token, context: ConversionContext): void {
 
     // Text content
     case 'text':
-    case 'code_inline':
       handleTextToken(token, context);
+      break;
+    case 'code_inline':
+      handleCodeInlineToken(token, context);
       break;
 
     // Inline formatting
@@ -234,6 +240,8 @@ function processToken(token: Token, context: ConversionContext): void {
     case 'table_close':
     case 'fence':
     case 'code_block':
+      handleCodeBlockToken(token, context);
+      break;
     case 'blockquote_open':
     case 'blockquote_close':
     case 'hr':
@@ -283,12 +291,25 @@ function handleParagraphOpen(context: ConversionContext): void {
 }
 
 function handleParagraphClose(context: ConversionContext): void {
-  // Skip if we're in a list
   if (context.listStack.length === 0) {
-    // Add double newline after paragraph for spacing
+    // Add double newline after non-list paragraphs for spacing.
     insertText('\n\n', context);
-    context.currentParagraphStart = undefined;
+  } else if (!lastInsertEndsWithNewline(context)) {
+    // End each list paragraph explicitly so nested list items don't collapse
+    // into their parent item text.
+    insertText('\n', context);
   }
+
+  const currentListItem = getCurrentOpenListItem(context);
+  if (currentListItem) {
+    const paragraphEndIndex = lastInsertEndsWithNewline(context)
+      ? context.currentIndex - 1
+      : context.currentIndex;
+    if (paragraphEndIndex > currentListItem.startIndex) {
+      currentListItem.endIndex = paragraphEndIndex;
+    }
+  }
+  context.currentParagraphStart = undefined;
 }
 
 // --- List Handlers ---
@@ -299,33 +320,42 @@ function handleListItemOpen(context: ConversionContext): void {
   }
 
   const currentList = context.listStack[context.listStack.length - 1];
-  const listKey = `${currentList.type}_${currentList.level}`;
+  const itemStart = context.currentIndex;
 
-  // Get or create list ID
-  if (!context.listIds.has(listKey)) {
-    // Generate a unique list ID
-    const listId = `list_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
-    context.listIds.set(listKey, listId);
+  // Docs API uses leading tabs to infer list nesting levels.
+  if (currentList.level > 0) {
+    insertText('\t'.repeat(currentList.level), context);
   }
 
-  const listId = context.listIds.get(listKey)!;
-
-  // Track the start of this list item
-  const itemStart = context.currentIndex;
-  context.pendingListItems.push({
+  const listItem: PendingListItem = {
     startIndex: itemStart,
-    listId,
     nestingLevel: currentList.level,
-    isOrdered: currentList.type === 'ordered'
-  });
+    bulletPreset: currentList.type === 'ordered'
+      ? 'NUMBERED_DECIMAL_ALPHA_ROMAN'
+      : 'BULLET_DISC_CIRCLE_SQUARE',
+    taskPrefixProcessed: false
+  };
+  context.pendingListItems.push(listItem);
+  context.openListItemStack.push(context.pendingListItems.length - 1);
 }
 
 function handleListItemClose(context: ConversionContext): void {
-  if (context.pendingListItems.length > 0) {
-    const lastItem = context.pendingListItems[context.pendingListItems.length - 1];
-    lastItem.endIndex = context.currentIndex;
+  const openIndex = context.openListItemStack.pop();
+  if (openIndex === undefined) {
+    return;
+  }
 
-    // Add newline after list item
+  const listItem = context.pendingListItems[openIndex];
+  if (listItem.endIndex === undefined) {
+    const computedEndIndex = lastInsertEndsWithNewline(context)
+      ? context.currentIndex - 1
+      : context.currentIndex;
+    if (computedEndIndex > listItem.startIndex) {
+      listItem.endIndex = computedEndIndex;
+    }
+  }
+
+  if (!lastInsertEndsWithNewline(context)) {
     insertText('\n', context);
   }
 }
@@ -333,8 +363,19 @@ function handleListItemClose(context: ConversionContext): void {
 // --- Text Handling ---
 
 function handleTextToken(token: Token, context: ConversionContext): void {
-  const text = token.content;
+  let text = token.content;
   if (!text) return;
+
+  const currentListItem = getCurrentOpenListItem(context);
+  if (currentListItem && !currentListItem.taskPrefixProcessed) {
+    currentListItem.taskPrefixProcessed = true;
+    const taskPrefixMatch = text.match(/^\[( |x|X)\]\s+/);
+    if (taskPrefixMatch) {
+      currentListItem.bulletPreset = 'BULLET_CHECKBOX';
+      text = text.slice(taskPrefixMatch[0].length);
+      if (!text) return;
+    }
+  }
 
   const startIndex = context.currentIndex;
   const endIndex = startIndex + text.length;
@@ -350,6 +391,44 @@ function handleTextToken(token: Token, context: ConversionContext): void {
       endIndex,
       formatting: currentFormatting
     });
+  }
+}
+
+function handleCodeInlineToken(token: Token, context: ConversionContext): void {
+  context.formattingStack.push({ code: true });
+  handleTextToken(token, context);
+  popFormatting(context, 'code');
+}
+
+function handleCodeBlockToken(token: Token, context: ConversionContext): void {
+  const normalizedContent = token.content.endsWith('\n')
+    ? token.content.slice(0, -1)
+    : token.content;
+  const lines = normalizedContent.length > 0 ? normalizedContent.split('\n') : [''];
+
+  for (const line of lines) {
+    const startIndex = context.currentIndex;
+    if (line.length > 0) {
+      insertText(line, context);
+      context.textRanges.push({
+        startIndex,
+        endIndex: context.currentIndex,
+        formatting: { code: true }
+      });
+    } else {
+      // Keep blank lines inside fenced blocks visible.
+      insertText(' ', context);
+      context.textRanges.push({
+        startIndex,
+        endIndex: context.currentIndex,
+        formatting: { code: true }
+      });
+    }
+    insertText('\n', context);
+  }
+
+  if (!lastInsertEndsWithDoubleNewline(context)) {
+    insertText('\n', context);
   }
 }
 
@@ -378,6 +457,7 @@ function mergeFormattingStack(stack: FormattingState[]): FormattingState {
     if (state.bold !== undefined) merged.bold = state.bold;
     if (state.italic !== undefined) merged.italic = state.italic;
     if (state.strikethrough !== undefined) merged.strikethrough = state.strikethrough;
+    if (state.code !== undefined) merged.code = state.code;
     if (state.link !== undefined) merged.link = state.link;
   }
 
@@ -388,6 +468,7 @@ function hasFormatting(formatting: FormattingState): boolean {
   return formatting.bold === true ||
          formatting.italic === true ||
          formatting.strikethrough === true ||
+         formatting.code === true ||
          formatting.link !== undefined;
 }
 
@@ -414,15 +495,18 @@ function finalizeFormatting(context: ConversionContext): void {
       rangeLocation.tabId = context.tabId;
     }
 
-    // Apply text style (bold, italic, strikethrough)
-    if (range.formatting.bold || range.formatting.italic || range.formatting.strikethrough) {
+    // Apply text style (bold, italic, strikethrough, inline/block code).
+    if (range.formatting.bold || range.formatting.italic || range.formatting.strikethrough || range.formatting.code) {
       const styleRequest = buildUpdateTextStyleRequest(
         range.startIndex,
         range.endIndex,
         {
           bold: range.formatting.bold,
           italic: range.formatting.italic,
-          strikethrough: range.formatting.strikethrough
+          strikethrough: range.formatting.strikethrough,
+          fontFamily: range.formatting.code ? CODE_FONT_FAMILY : undefined,
+          foregroundColor: range.formatting.code ? CODE_TEXT_HEX : undefined,
+          backgroundColor: range.formatting.code ? CODE_BACKGROUND_HEX : undefined
         },
         context.tabId
       );
@@ -460,9 +544,14 @@ function finalizeFormatting(context: ConversionContext): void {
     }
   }
 
-  // Apply list formatting
-  for (const listItem of context.pendingListItems) {
-    if (listItem.endIndex !== undefined) {
+  // Apply list formatting from bottom-to-top so index shifts from tab
+  // consumption do not invalidate later requests.
+  const listItemsForFormatting = context.pendingListItems
+    .filter((listItem) => listItem.endIndex !== undefined && listItem.endIndex > listItem.startIndex)
+    .sort((a, b) => b.startIndex - a.startIndex);
+
+  for (const listItem of listItemsForFormatting) {
+    if (listItem.endIndex !== undefined && listItem.endIndex > listItem.startIndex) {
       const rangeLocation: docs_v1.Schema$Range = {
         startIndex: listItem.startIndex,
         endIndex: listItem.endIndex
@@ -471,18 +560,28 @@ function finalizeFormatting(context: ConversionContext): void {
         rangeLocation.tabId = context.tabId;
       }
 
-      const bulletPreset = listItem.isOrdered
-        ? 'NUMBERED_DECIMAL_ALPHA_ROMAN'
-        : 'BULLET_DISC_CIRCLE_SQUARE';
-
       context.formatRequests.push({
         createParagraphBullets: {
           range: rangeLocation,
-          bulletPreset,
-          // Note: Google Docs API automatically manages nesting levels
-          // We include nestingLevel but the API may adjust it
+          bulletPreset: listItem.bulletPreset
         }
       });
     }
   }
+}
+
+function getCurrentOpenListItem(context: ConversionContext): PendingListItem | null {
+  const openIndex = context.openListItemStack[context.openListItemStack.length - 1];
+  if (openIndex === undefined) return null;
+  return context.pendingListItems[openIndex] ?? null;
+}
+
+function lastInsertEndsWithNewline(context: ConversionContext): boolean {
+  const lastInsert = context.insertRequests[context.insertRequests.length - 1]?.insertText?.text;
+  return Boolean(lastInsert && lastInsert.endsWith('\n'));
+}
+
+function lastInsertEndsWithDoubleNewline(context: ConversionContext): boolean {
+  const lastInsert = context.insertRequests[context.insertRequests.length - 1]?.insertText?.text;
+  return Boolean(lastInsert && lastInsert.endsWith('\n\n'));
 }


### PR DESCRIPTION
## Summary
This PR improves markdown-to-Google-Docs fidelity used by `appendMarkdownToGoogleDoc` and `replaceDocumentWithMarkdown` by adding support for patterns that previously degraded formatting.

## What Changed
- Add inline-code styling (monospace + code-like colors).
- Add fenced/code-block rendering and code styling.
- Preserve nested list levels via leading-tab indentation.
- Convert markdown task lists (`[x]` / `[ ]`) to Google Docs checkbox bullets.
- Prevent list bullet ranges from bleeding into following headings.
- Apply list bullet requests bottom-up to avoid index-shift failures.
- Add regression tests for the above behavior.

## Validation
- Ran: `node --test tests/markdown.test.js`
- Result: 22 passed, 0 failed.

## Before / After Evidence (Public-Safe Fixture)
Used a synthetic markdown fixture (no internal content).

- Before (origin/main converter):
  - checkbox bullets: not generated
  - monospace code style requests: 0

<img width="1147" height="539" alt="Screenshot 2026-02-10 at 10 30 41 PM" src="https://github.com/user-attachments/assets/22f9ff4f-047b-45f1-97b8-9e5f677a2cf9" />

- After (this branch): 
  - checkbox bullets: generated
  - monospace code style requests: 3

<img width="1145" height="598" alt="Screenshot 2026-02-10 at 10 30 48 PM" src="https://github.com/user-attachments/assets/745891d5-1b05-48eb-8aac-7dd1fc2528f2" />
