### PR TITLE
Added tabId to missing tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,17 +2286,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -2739,9 +2728,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src/tools/docs/formatting/applyTextStyle.ts
+++ b/src/tools/docs/formatting/applyTextStyle.ts
@@ -19,7 +19,7 @@ export function register(server: FastMCP) {
       let { startIndex, endIndex } = args.target as any; // Will be updated if target is text
 
       log.info(
-        `Applying text style in doc ${args.documentId}. Target: ${JSON.stringify(args.target)}, Style: ${JSON.stringify(args.style)}`
+        `Applying text style in doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}. Target: ${JSON.stringify(args.target)}, Style: ${JSON.stringify(args.style)}`
       );
 
       try {
@@ -29,11 +29,12 @@ export function register(server: FastMCP) {
             docs,
             args.documentId,
             args.target.textToFind,
-            args.target.matchInstance
+            args.target.matchInstance,
+            args.tabId
           );
           if (!range) {
             throw new UserError(
-              `Could not find instance ${args.target.matchInstance} of text "${args.target.textToFind}".`
+              `Could not find instance ${args.target.matchInstance} of text "${args.target.textToFind}"${args.tabId ? ` in tab ${args.tabId}` : ''}.`
             );
           }
           startIndex = range.startIndex;
@@ -54,14 +55,15 @@ export function register(server: FastMCP) {
         const requestInfo = GDocsHelpers.buildUpdateTextStyleRequest(
           startIndex,
           endIndex,
-          args.style
+          args.style,
+          args.tabId
         );
         if (!requestInfo) {
           return 'No valid text styling options were provided.';
         }
 
         await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [requestInfo.request]);
-        return `Successfully applied text style (${requestInfo.fields.join(', ')}) to range ${startIndex}-${endIndex}.`;
+        return `Successfully applied text style (${requestInfo.fields.join(', ')}) to range ${startIndex}-${endIndex}${args.tabId ? ` in tab ${args.tabId}` : ''}.`;
       } catch (error: any) {
         log.error(`Error applying text style in doc ${args.documentId}: ${error.message || error}`);
         if (error instanceof UserError) throw error;

--- a/src/tools/docs/insertPageBreak.ts
+++ b/src/tools/docs/insertPageBreak.ts
@@ -18,18 +18,47 @@ export function register(server: FastMCP) {
         .describe(
           "1-based character index within the document body. Use readDocument with format='json' to inspect indices."
         ),
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab to insert into. Use listDocumentTabs to get tab IDs. If not specified, inserts into the first tab.'
+        ),
     }),
     execute: async (args, { log }) => {
       const docs = await getDocsClient();
-      log.info(`Inserting page break in doc ${args.documentId} at index ${args.index}`);
+      log.info(
+        `Inserting page break in doc ${args.documentId} at index ${args.index}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
       try {
+        // If tabId is specified, verify the tab exists
+        if (args.tabId) {
+          const docInfo = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields: 'tabs(tabProperties,documentTab)',
+          });
+          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
+          if (!targetTab) {
+            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
+          }
+          if (!targetTab.documentTab) {
+            throw new UserError(
+              `Tab "${args.tabId}" does not have content (may not be a document tab).`
+            );
+          }
+        }
+
+        const location: any = { index: args.index };
+        if (args.tabId) {
+          location.tabId = args.tabId;
+        }
+
         const request: docs_v1.Schema$Request = {
-          insertPageBreak: {
-            location: { index: args.index },
-          },
+          insertPageBreak: { location },
         };
         await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [request]);
-        return `Successfully inserted page break at index ${args.index}.`;
+        return `Successfully inserted page break at index ${args.index}${args.tabId ? ` in tab ${args.tabId}` : ''}.`;
       } catch (error: any) {
         log.error(
           `Error inserting page break in doc ${args.documentId}: ${error.message || error}`

--- a/src/tools/docs/insertTable.ts
+++ b/src/tools/docs/insertTable.ts
@@ -20,16 +20,46 @@ export function register(server: FastMCP) {
         .describe(
           "1-based character index within the document body. Use readDocument with format='json' to inspect indices."
         ),
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab to insert into. Use listDocumentTabs to get tab IDs. If not specified, inserts into the first tab.'
+        ),
     }),
     execute: async (args, { log }) => {
       const docs = await getDocsClient();
       log.info(
-        `Inserting ${args.rows}x${args.columns} table in doc ${args.documentId} at index ${args.index}`
+        `Inserting ${args.rows}x${args.columns} table in doc ${args.documentId} at index ${args.index}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
       );
       try {
-        await GDocsHelpers.createTable(docs, args.documentId, args.rows, args.columns, args.index);
-        // The API response contains info about the created table, but might be too complex to return here.
-        return `Successfully inserted a ${args.rows}x${args.columns} table at index ${args.index}.`;
+        // If tabId is specified, verify the tab exists
+        if (args.tabId) {
+          const docInfo = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields: 'tabs(tabProperties,documentTab)',
+          });
+          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
+          if (!targetTab) {
+            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
+          }
+          if (!targetTab.documentTab) {
+            throw new UserError(
+              `Tab "${args.tabId}" does not have content (may not be a document tab).`
+            );
+          }
+        }
+
+        await GDocsHelpers.createTable(
+          docs,
+          args.documentId,
+          args.rows,
+          args.columns,
+          args.index,
+          args.tabId
+        );
+        return `Successfully inserted a ${args.rows}x${args.columns} table at index ${args.index}${args.tabId ? ` in tab ${args.tabId}` : ''}.`;
       } catch (error: any) {
         log.error(`Error inserting table in doc ${args.documentId}: ${error.message || error}`);
         if (error instanceof UserError) throw error;

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,12 @@ export const ApplyTextStyleToolParameters = DocumentIdParameter.extend({
     (styleArgs) => Object.values(styleArgs).some((v) => v !== undefined),
     { message: 'At least one text style option must be provided.' }
   ).describe('The text styling to apply.'),
+  tabId: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of the specific tab to apply formatting in. Use listDocumentTabs to get tab IDs. If not specified, operates on the first tab.'
+    ),
 });
 export type ApplyTextStyleToolArgs = z.infer<typeof ApplyTextStyleToolParameters>;
 
@@ -190,6 +196,12 @@ export const ApplyParagraphStyleToolParameters = DocumentIdParameter.extend({
     (styleArgs) => Object.values(styleArgs).some((v) => v !== undefined),
     { message: 'At least one paragraph style option must be provided.' }
   ).describe('The paragraph styling to apply.'),
+  tabId: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of the specific tab to apply formatting in. Use listDocumentTabs to get tab IDs. If not specified, operates on the first tab.'
+    ),
 });
 export type ApplyParagraphStyleToolArgs = z.infer<typeof ApplyParagraphStyleToolParameters>;
 


### PR DESCRIPTION
Here's a summary of everything that was changed.

## Core Helper Functions (googleDocsApiHelpers.ts)

* `findTextRange()` -- Added optional tabId parameter. When provided, fetches with includeTabsContent: true, locates the target tab via findTabById(), and searches that tab's documentTab.body.content instead of the default document.body.content. Throws a UserError if the tab is not found.
* `getParagraphRange()` -- Same pattern as findTextRange(). Now accepts optional tabId and searches within the correct tab's content.
* `createTable()` -- Added optional tabId parameter, sets it on the location object when provided.
* `insertInlineImage()` -- Added optional tabId parameter, sets it on the location object when provided.

## Tool Parameter Schemas (types.ts)

* `ApplyTextStyleToolParameters` -- Added optional tabId field.
* `ApplyParagraphStyleToolParameters` -- Added optional tabId field.

## Tool Implementations

* `applyTextStyle` -- Threads tabId to both findTextRange() and buildUpdateTextStyleRequest().
* `applyParagraphStyle `-- Threads tabId to findTextRange(), getParagraphRange(), and buildUpdateParagraphStyleRequest().
* `insertTable` -- Added tabId parameter with tab existence verification, passes through to createTable().
* `insertPageBreak` -- Added tabId parameter with tab existence verification, sets it on the location object.
* `insertImage` -- Added tabId parameter with tab existence verification, passes through to insertInlineImage().

## Tests (googleDocsApiHelpers.test.ts)

* `findTextRange` with tabId correctly searches tab-specific content
* `findTextRange` throws UserError for nonexistent tabId
* `findTextRange` without tabId does not use includeTabsContent
* `getParagraphRange` with tabId correctly searches tab-specific content
* `getParagraphRange` throws UserError for nonexistent tabId

Fixes https://github.com/a-bonus/google-docs-mcp/issues/39, https://github.com/a-bonus/google-docs-mcp/issues/11, and https://github.com/a-bonus/google-docs-mcp/issues/34