### PR TITLE
Add full markdown table support

### DIFF
--- a/src/markdown-transformer/markdownToDocs.ts
+++ b/src/markdown-transformer/markdownToDocs.ts
@@ -710,10 +710,15 @@ function handleTableClose(tableState: TableState, context: ConversionContext): v
         const absStart = adjustedIndex + range.startIndex;
         const absEnd = adjustedIndex + range.endIndex;
 
-        if (range.formatting.bold || range.formatting.italic ||
-            range.formatting.strikethrough || range.formatting.code) {
+        if (
+          range.formatting.bold ||
+          range.formatting.italic ||
+          range.formatting.strikethrough ||
+          range.formatting.code
+        ) {
           const styleReq = buildUpdateTextStyleRequest(
-            absStart, absEnd,
+            absStart,
+            absEnd,
             {
               bold: range.formatting.bold,
               italic: range.formatting.italic,
@@ -729,7 +734,8 @@ function handleTableClose(tableState: TableState, context: ConversionContext): v
 
         if (range.formatting.link) {
           const linkReq = buildUpdateTextStyleRequest(
-            absStart, absEnd,
+            absStart,
+            absEnd,
             { linkUrl: range.formatting.link },
             context.tabId
           );


### PR DESCRIPTION
## Summary

- Tables were previously no-ops — all table tokens were explicitly set to `break` in `markdownToDocs.ts`, so any markdown table was silently dropped
- This patch implements full table support: inserts a correctly-sized table via the Google Docs `insertTable` API, then populates each cell with text and inline formatting
- Header rows are automatically bolded

## Implementation details

The core challenge is that the Google Docs API requires knowing all indices upfront before inserting text, and inserting content shifts all subsequent indices. The approach:

1. **Buffer cell content** during token processing — store each cell's text runs (with inline formatting spans) into a `TableState` structure rather than emitting requests immediately
2. **On `table_close`** — emit one `insertTable` request, then iterate all cells in order, tracking cumulative inserted character counts to compute correct absolute indices

**Key index formulas** (verified against the Docs API table structure):
```
cellContentIndex(T, r, c, C) = T + 4 + r * (1 + 2*C) + 2*c
emptyTableSize(R, C)         = 3 + R * (1 + 2*C)
currentIndex after table     = tableStartIndex + emptyTableSize + cumulativeTextLength
```

## Testing

Tested with an 8-table document (mixed column counts, bold/italic inline formatting in cells) pushed to Google Drive via `replaceDocumentWithMarkdown`. All tables rendered correctly with bold header rows.

Before this patch, the same document produced garbled output with all table content concatenated into the surrounding paragraph text.

## Notes

- Only `replaceDocumentWithMarkdown` exercises the full transformer path — `createDocument` with `contentFormat: "markdown"` also works for tables via this same transformer
- No changes to the public API or other markdown elements