### PR TITLE
feat: Apps Script fallback for local image insertion in enterprise environments

### DIFF
--- a/apps_script/mcp_image_inserter.gs
+++ b/apps_script/mcp_image_inserter.gs
@@ -1,0 +1,100 @@
+/**
+ * MCP Google Docs Server — Apps Script Image Inserter
+ *
+ * Finds [mcp-img-FILEID] markers in a document and replaces each one
+ * with the corresponding Drive image (looked up by file ID).
+ *
+ * Deployed as an API Executable so the MCP server can call it via
+ * google.script('v1').scripts.run().
+ *
+ * Setup:
+ *   1. Create a new Apps Script project at https://script.google.com
+ *   2. Link the project to the SAME Google Cloud project as the OAuth client
+ *      used by mcp-googledocs-server (Project Settings → Change project).
+ *   3. Paste this file's contents.
+ *   4. Deploy → New deployment → Select type: API Executable → Deploy.
+ *   5. Copy the Deployment ID into secrets.yaml under
+ *      google.apps_script_deployment_id.
+ */
+
+/**
+ * Replace a single [mcp-img-<fileId>] marker with the actual image.
+ *
+ * @param {string} documentId  Google Docs document ID
+ * @param {string} driveFileId Google Drive file ID of the uploaded image
+ * @param {number} [maxWidthRatio=0.8]  Max fraction of page width
+ * @param {number} [maxHeightPx=500]    Max height in pixels
+ * @return {object} { success, message }
+ */
+function insertImageByFileId(documentId, driveFileId, maxWidthRatio, maxHeightPx) {
+  maxWidthRatio = maxWidthRatio || 0.8;
+  maxHeightPx   = maxHeightPx   || 500;
+
+  try {
+    var doc  = DocumentApp.openById(documentId);
+    var body = doc.getBody();
+
+    var marker = '[mcp-img-' + driveFileId + ']';
+    var found  = body.findText('\\[mcp-img-' + escapeRegex(driveFileId) + '\\]');
+
+    if (!found) {
+      return { success: false, message: 'Marker not found: ' + marker };
+    }
+
+    var textEl   = found.getElement().asText();
+    var start    = found.getStartOffset();
+    var endIncl  = found.getEndOffsetInclusive();
+
+    var file = DriveApp.getFileById(driveFileId);
+    var blob = file.getBlob();
+
+    textEl.deleteText(start, endIncl);
+
+    var paragraph   = textEl.getParent().asParagraph();
+    var childIndex  = paragraph.getChildIndex(textEl);
+    var insertPos   = (start === 0) ? childIndex : childIndex + 1;
+    var inlineImage = paragraph.insertInlineImage(insertPos, blob);
+
+    // Resize
+    var pageWidthPts    = body.getPageWidth();
+    var marginLeftPts   = body.getMarginLeft();
+    var marginRightPts  = body.getMarginRight();
+    var availableWidthPts = pageWidthPts - marginLeftPts - marginRightPts;
+    var POINTS_PER_INCH = 72;
+    var IMAGE_DPI       = 96;
+    var availableWidthPx = Math.round(availableWidthPts * IMAGE_DPI / POINTS_PER_INCH);
+
+    var imgWidth  = inlineImage.getWidth();
+    var imgHeight = inlineImage.getHeight();
+    var maxWidth  = Math.round(availableWidthPx * maxWidthRatio);
+
+    var targetWidth  = imgWidth;
+    var targetHeight = imgHeight;
+    var scale = 1;
+
+    if (imgWidth > maxWidth) {
+      scale = maxWidth / imgWidth;
+    }
+    if (imgHeight * scale > maxHeightPx) {
+      scale = maxHeightPx / imgHeight;
+    }
+    if (scale < 1) {
+      targetWidth  = Math.round(imgWidth  * scale);
+      targetHeight = Math.round(imgHeight * scale);
+      inlineImage.setWidth(targetWidth);
+      inlineImage.setHeight(targetHeight);
+    }
+
+    return {
+      success: true,
+      message: 'Inserted image (' + targetWidth + 'x' + targetHeight + ')'
+    };
+
+  } catch (error) {
+    return { success: false, message: 'Error: ' + error.toString() };
+  }
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,6 +42,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/documents',
   'https://www.googleapis.com/auth/drive',
   'https://www.googleapis.com/auth/spreadsheets',
+  'https://www.googleapis.com/auth/script.external_request',
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,5 +1,5 @@
 // src/clients.ts
-import { google, docs_v1, drive_v3, sheets_v4 } from 'googleapis';
+import { google, docs_v1, drive_v3, sheets_v4, script_v1 } from 'googleapis';
 import { UserError } from 'fastmcp';
 import { OAuth2Client } from 'google-auth-library';
 import { authorize } from './auth.js';
@@ -9,32 +9,32 @@ let authClient: OAuth2Client | null = null;
 let googleDocs: docs_v1.Docs | null = null;
 let googleDrive: drive_v3.Drive | null = null;
 let googleSheets: sheets_v4.Sheets | null = null;
+let googleScript: script_v1.Script | null = null;
 
 // --- Initialization ---
 export async function initializeGoogleClient() {
   if (googleDocs && googleDrive && googleSheets)
-    return { authClient, googleDocs, googleDrive, googleSheets };
+    return { authClient, googleDocs, googleDrive, googleSheets, googleScript };
   if (!authClient) {
-    // Check authClient instead of googleDocs to allow re-attempt
     try {
       logger.info('Attempting to authorize Google API client...');
       const client = await authorize();
-      authClient = client; // Assign client here
+      authClient = client;
       googleDocs = google.docs({ version: 'v1', auth: authClient });
       googleDrive = google.drive({ version: 'v3', auth: authClient });
       googleSheets = google.sheets({ version: 'v4', auth: authClient });
+      googleScript = google.script({ version: 'v1', auth: authClient });
       logger.info('Google API client authorized successfully.');
     } catch (error) {
       logger.error('FATAL: Failed to initialize Google API client:', error);
-      authClient = null; // Reset on failure
+      authClient = null;
       googleDocs = null;
       googleDrive = null;
       googleSheets = null;
-      // Decide if server should exit or just fail tools
+      googleScript = null;
       throw new Error('Google client initialization failed. Cannot start server tools.');
     }
   }
-  // Ensure googleDocs, googleDrive, and googleSheets are set if authClient is valid
   if (authClient && !googleDocs) {
     googleDocs = google.docs({ version: 'v1', auth: authClient });
   }
@@ -44,12 +44,15 @@ export async function initializeGoogleClient() {
   if (authClient && !googleSheets) {
     googleSheets = google.sheets({ version: 'v4', auth: authClient });
   }
+  if (authClient && !googleScript) {
+    googleScript = google.script({ version: 'v1', auth: authClient });
+  }
 
   if (!googleDocs || !googleDrive || !googleSheets) {
     throw new Error('Google Docs, Drive, and Sheets clients could not be initialized.');
   }
 
-  return { authClient, googleDocs, googleDrive, googleSheets };
+  return { authClient, googleDocs, googleDrive, googleSheets, googleScript };
 }
 
 // --- Helper to get Docs client within tools ---
@@ -94,4 +97,15 @@ export async function getAuthClient() {
     );
   }
   return client;
+}
+
+// --- Helper to get Script client within tools ---
+export async function getScriptClient() {
+  const { googleScript: script } = await initializeGoogleClient();
+  if (!script) {
+    throw new UserError(
+      'Google Script client is not initialized. Authentication might have failed during startup or lost connection.'
+    );
+  }
+  return script;
 }

--- a/src/googleDocsApiHelpers.ts
+++ b/src/googleDocsApiHelpers.ts
@@ -922,26 +922,28 @@ export async function insertInlineImage(
 }
 
 /**
- * Uploads a local image file to Google Drive and returns its public URL
- * @param drive - Google Drive API client
- * @param localFilePath - Path to the local image file
- * @param parentFolderId - Optional parent folder ID (defaults to root)
- * @returns Promise with the public webContentLink URL
+ * Uploads a local image file to Google Drive.
+ *
+ * When `skipPublicSharing` is false (default), the file is made publicly
+ * readable and its webContentLink is returned — required for the Docs API
+ * insertInlineImage approach.
+ *
+ * When `skipPublicSharing` is true, only the Drive file ID is returned.
+ * Use this with the Apps Script insertion path where no public URL is needed.
  */
 export async function uploadImageToDrive(
   drive: any, // drive_v3.Drive type
   localFilePath: string,
-  parentFolderId?: string
+  parentFolderId?: string,
+  skipPublicSharing: boolean = false,
 ): Promise<string> {
   const fs = await import('fs');
   const path = await import('path');
 
-  // Verify file exists
   if (!fs.existsSync(localFilePath)) {
     throw new UserError(`Image file not found: ${localFilePath}`);
   }
 
-  // Get file name and mime type
   const fileName = path.basename(localFilePath);
   const mimeTypeMap: { [key: string]: string } = {
     '.jpg': 'image/jpeg',
@@ -956,7 +958,6 @@ export async function uploadImageToDrive(
   const ext = path.extname(localFilePath).toLowerCase();
   const mimeType = mimeTypeMap[ext] || 'application/octet-stream';
 
-  // Upload file to Drive
   const fileMetadata: any = {
     name: fileName,
     mimeType: mimeType,
@@ -983,7 +984,10 @@ export async function uploadImageToDrive(
     throw new Error('Failed to upload image to Drive - no file ID returned');
   }
 
-  // Make the file publicly readable
+  if (skipPublicSharing) {
+    return fileId;
+  }
+
   await drive.permissions.create({
     fileId: fileId,
     requestBody: {
@@ -993,7 +997,6 @@ export async function uploadImageToDrive(
     supportsAllDrives: true,
   });
 
-  // Get the webContentLink
   const fileInfo = await drive.files.get({
     fileId: fileId,
     fields: 'webContentLink',
@@ -1006,6 +1009,51 @@ export async function uploadImageToDrive(
   }
 
   return webContentLink;
+}
+
+/**
+ * Inserts an image into a Google Doc via Apps Script.
+ *
+ * Flow:
+ *   1. Insert a unique marker string at the target index using the Docs API.
+ *   2. Call the deployed Apps Script which finds the marker and replaces it
+ *      with the actual image blob from Drive (no public sharing needed).
+ */
+export async function insertImageViaAppsScript(
+  docs: Docs,
+  scriptClient: any, // script_v1.Script type
+  deploymentId: string,
+  documentId: string,
+  driveFileId: string,
+  charIndex: number,
+  tabId?: string,
+): Promise<void> {
+  const marker = `[mcp-img-${driveFileId}]`;
+
+  // Step 1: Insert marker at the requested position via Docs API
+  const location: any = { index: charIndex };
+  if (tabId) {
+    location.tabId = tabId;
+  }
+
+  await executeBatchUpdate(docs, documentId, [
+    { insertText: { location, text: marker } },
+  ]);
+
+  // Step 2: Call Apps Script to replace the marker with the image
+  const response = await scriptClient.scripts.run({
+    scriptId: deploymentId,
+    requestBody: {
+      function: 'insertImageByFileId',
+      parameters: [documentId, driveFileId],
+    },
+  });
+
+  const result = response.data?.response?.result;
+  if (!result || !result.success) {
+    const msg = result?.message || 'Unknown Apps Script error';
+    throw new Error(`Apps Script image insertion failed: ${msg}`);
+  }
 }
 
 // --- Tab Management Helpers ---

--- a/src/tools/docs/insertImage.ts
+++ b/src/tools/docs/insertImage.ts
@@ -1,9 +1,10 @@
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
-import { getDocsClient, getDriveClient } from '../../clients.js';
+import { getDocsClient, getDriveClient, getScriptClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { logger } from '../../logger.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -46,9 +47,9 @@ export function register(server: FastMCP) {
       }),
     execute: async (args, { log }) => {
       const docs = await getDocsClient();
+      const appsScriptDeploymentId = process.env.APPS_SCRIPT_DEPLOYMENT_ID;
 
       try {
-        // If tabId is specified, verify the tab exists
         if (args.tabId) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
@@ -66,6 +67,56 @@ export function register(server: FastMCP) {
           }
         }
 
+        // --- Apps Script path: local files when APPS_SCRIPT_DEPLOYMENT_ID is set ---
+        if (args.localImagePath && appsScriptDeploymentId) {
+          const drive = await getDriveClient();
+          const scriptClient = await getScriptClient();
+
+          log.info(
+            `[AppsScript] Uploading ${args.localImagePath} to Drive (no public sharing)`
+          );
+
+          let parentFolderId: string | undefined;
+          try {
+            const docInfo = await drive.files.get({
+              fileId: args.documentId,
+              fields: 'parents',
+              supportsAllDrives: true,
+            });
+            if (docInfo.data.parents && docInfo.data.parents.length > 0) {
+              parentFolderId = docInfo.data.parents[0];
+            }
+          } catch (folderError) {
+            log.warn(
+              `Could not determine document's parent folder, using Drive root: ${folderError}`
+            );
+          }
+
+          const driveFileId = await GDocsHelpers.uploadImageToDrive(
+            drive,
+            args.localImagePath,
+            parentFolderId,
+            true, // skipPublicSharing
+          );
+
+          log.info(
+            `[AppsScript] Inserting image via marker at index ${args.index} (fileId: ${driveFileId})`
+          );
+
+          await GDocsHelpers.insertImageViaAppsScript(
+            docs,
+            scriptClient,
+            appsScriptDeploymentId,
+            args.documentId,
+            driveFileId,
+            args.index,
+            args.tabId,
+          );
+
+          return `Successfully inserted local image at index ${args.index} via Apps Script${args.tabId ? ` in tab ${args.tabId}` : ''}.`;
+        }
+
+        // --- Standard path: public URL insertion via Docs API ---
         let resolvedUrl: string;
 
         if (args.localImagePath) {
@@ -74,7 +125,6 @@ export function register(server: FastMCP) {
             `Uploading local image ${args.localImagePath} and inserting at index ${args.index} in doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
           );
 
-          // Get the document's parent folder
           let parentFolderId: string | undefined;
           try {
             const docInfo = await drive.files.get({
@@ -94,7 +144,7 @@ export function register(server: FastMCP) {
           resolvedUrl = await GDocsHelpers.uploadImageToDrive(
             drive,
             args.localImagePath,
-            parentFolderId
+            parentFolderId,
           );
           log.info(`Image uploaded successfully, URL: ${resolvedUrl}`);
         } else {


### PR DESCRIPTION
## Summary

Enterprise Google Workspace environments often block public file sharing (`drive.permissions.create({ type: 'anyone' })`), which causes `insertImage` with `localImagePath` to fail with "insufficient permissions".

This PR adds an opt-in Apps Script-based fallback that inserts images directly from Drive blobs via `DocumentApp`, bypassing the public sharing requirement entirely.

### How it works

1. Upload image to Drive (no public sharing)
2. Insert a `[mcp-img-FILEID]` marker at the target position via the Docs API
3. Call a deployed Apps Script function that finds the marker, fetches the image blob from Drive, and replaces the marker with an inline image

### Changes

- **`src/auth.ts`** — Added `script.external_request` OAuth scope
- **`src/clients.ts`** — Added Script API client (`google.script('v1')`) and `getScriptClient()` helper
- **`src/googleDocsApiHelpers.ts`** — Added `skipPublicSharing` option to `uploadImageToDrive()`, added `insertImageViaAppsScript()` helper
- **`src/tools/docs/insertImage.ts`** — Uses Apps Script path when `APPS_SCRIPT_DEPLOYMENT_ID` env var is set; falls back to existing behavior otherwise
- **`apps_script/mcp_image_inserter.gs`** — Ready-to-deploy Apps Script function

### Backward compatibility

Fully backward compatible. The Apps Script path only activates when `APPS_SCRIPT_DEPLOYMENT_ID` is set as an environment variable. Without it, behavior is identical to before.

### Setup (for users who need this)

1. Create an Apps Script project linked to the same Google Cloud project as the OAuth client
2. Paste the contents of `apps_script/mcp_image_inserter.gs`
3. Deploy as API Executable
4. Set `APPS_SCRIPT_DEPLOYMENT_ID` env var to the deployment ID

## Test plan

- [x] Tested with corporate Google Workspace that blocks public sharing
- [x] Local PNG image successfully inserted via Apps Script path
- [x] URL-based image insertion still works unchanged
- [x] Server builds cleanly (`npm run build`)
- [x] Without `APPS_SCRIPT_DEPLOYMENT_ID`, existing behavior is unchanged

Made with [Cursor](https://cursor.com)