### PR TITLE
fix: pass valueRenderOption through to Google Sheets API

### DIFF
--- a/src/googleSheetsApiHelpers.ts
+++ b/src/googleSheetsApiHelpers.ts
@@ -75,12 +75,14 @@ export function normalizeRange(range: string, sheetName?: string): string {
 export async function readRange(
   sheets: Sheets,
   spreadsheetId: string,
-  range: string
+  range: string,
+  valueRenderOption: 'FORMATTED_VALUE' | 'UNFORMATTED_VALUE' | 'FORMULA' = 'FORMATTED_VALUE'
 ): Promise<sheets_v4.Schema$ValueRange> {
   try {
     const response = await sheets.spreadsheets.values.get({
       spreadsheetId,
       range,
+      valueRenderOption,
     });
     return response.data;
   } catch (error: any) {

--- a/src/tools/sheets/readSpreadsheet.ts
+++ b/src/tools/sheets/readSpreadsheet.ts
@@ -27,7 +27,12 @@ export function register(server: FastMCP) {
       log.info(`Reading spreadsheet ${args.spreadsheetId}, range: ${args.range}`);
 
       try {
-        const response = await SheetsHelpers.readRange(sheets, args.spreadsheetId, args.range);
+        const response = await SheetsHelpers.readRange(
+          sheets,
+          args.spreadsheetId,
+          args.range,
+          args.valueRenderOption
+        );
         const values = response.values || [];
         return JSON.stringify({ range: args.range, values }, null, 2);
       } catch (error: any) {


### PR DESCRIPTION
## Summary

- Fixes the `readSpreadsheet` tool silently ignoring the `valueRenderOption` parameter
- Adds the parameter to the `readRange()` helper and forwards it to `sheets.spreadsheets.values.get()`
- All existing tests pass, formatting verified with Prettier

Fixes #65

## Changes

| File | Change |
|------|--------|
| `src/googleSheetsApiHelpers.ts` | Added optional `valueRenderOption` param to `readRange()`, forwarded to API call |
| `src/tools/sheets/readSpreadsheet.ts` | Passed `args.valueRenderOption` through to `readRange()` |

## Test plan

- [x] `npm test` — 107 tests pass
- [x] `npm run format:check` — clean
- [x] `npm run build` — compiles without errors
- [x] Manual verification: `readSpreadsheet` with `valueRenderOption: "FORMULA"` now returns formula strings instead of computed values