### PR TITLE
feat: add duplicateSheet tool

### DIFF
--- a/src/tools/sheets/duplicateSheet.ts
+++ b/src/tools/sheets/duplicateSheet.ts
@@ -1,0 +1,68 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'duplicateSheet',
+    description:
+      'Duplicates a sheet (tab) within a spreadsheet, copying all values, formulas, formatting, validations, and conditional formatting. Use getSpreadsheetInfo to find the numeric sheet ID.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      sheetId: z
+        .number()
+        .int()
+        .describe(
+          'The numeric sheet ID to duplicate. Use getSpreadsheetInfo to find sheet IDs.'
+        ),
+      newSheetName: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          'Name for the duplicated sheet. If omitted, Google auto-names it "Copy of <original>".'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(
+        `Duplicating sheet ID ${args.sheetId} in spreadsheet ${args.spreadsheetId}${args.newSheetName ? ` as "${args.newSheetName}"` : ''}`
+      );
+
+      try {
+        const response = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                duplicateSheet: {
+                  sourceSheetId: args.sheetId,
+                  newSheetName: args.newSheetName,
+                },
+              },
+            ],
+          },
+        });
+
+        const duplicatedSheet = response.data.replies?.[0]?.duplicateSheet?.properties;
+
+        if (!duplicatedSheet) {
+          throw new UserError('Failed to duplicate sheet - no sheet properties returned.');
+        }
+
+        return `Successfully duplicated sheet as "${duplicatedSheet.title}" (Sheet ID: ${duplicatedSheet.sheetId}).`;
+      } catch (error: any) {
+        log.error(
+          `Error duplicating sheet in spreadsheet ${args.spreadsheetId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to duplicate sheet: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/index.ts
+++ b/src/tools/sheets/index.ts
@@ -7,6 +7,7 @@ import { register as getSpreadsheetInfo } from './getSpreadsheetInfo.js';
 import { register as addSpreadsheetSheet } from './addSpreadsheetSheet.js';
 import { register as createSpreadsheet } from './createSpreadsheet.js';
 import { register as listGoogleSheets } from './listGoogleSheets.js';
+import { register as duplicateSheet } from './duplicateSheet.js';
 
 // Formatting & validation
 import { register as formatCells } from './formatCells.js';
@@ -22,6 +23,7 @@ export function registerSheetsTools(server: FastMCP) {
   addSpreadsheetSheet(server);
   createSpreadsheet(server);
   listGoogleSheets(server);
+  duplicateSheet(server);
 
   // Formatting & validation
   formatCells(server);


### PR DESCRIPTION
## Summary

Adds a new `duplicateSheet` tool that duplicates a sheet (tab) within a spreadsheet, copying all values, formulas, formatting, validations, and conditional formatting.

Closes #67

## Changes

- **New:** `src/tools/sheets/duplicateSheet.ts` — Tool implementation using `spreadsheets.batchUpdate` with `DuplicateSheetRequest`
- **Modified:** `src/tools/sheets/index.ts` — Added import and registration

## Parameters

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `spreadsheetId` | string | Yes | The spreadsheet ID |
| `sheetId` | number (int) | Yes | Numeric sheet ID to duplicate |
| `newSheetName` | string | No | Name for the copy (auto-named if omitted) |

## Testing

Tested against a live Google Sheets spreadsheet:
- Duplicates sheet with all formulas intact
- Duplicates sheet with all formatting preserved
- Optional `newSheetName` works correctly
- Build passes (`tsc` with zero errors)