### PR TITLE
feat: add readCellFormat, copyFormatting, and batchWrite tools

### DIFF
--- a/src/googleSheetsApiHelpers.ts
+++ b/src/googleSheetsApiHelpers.ts
@@ -257,7 +257,7 @@ export async function addSheet(
  * Parses A1 notation range to extract sheet name and cell range
  * Returns {sheetName, a1Range} where a1Range is just the cell part (e.g., "A1:B2")
  */
-function parseRange(range: string): { sheetName: string | null; a1Range: string } {
+export function parseRange(range: string): { sheetName: string | null; a1Range: string } {
   if (range.includes('!')) {
     const parts = range.split('!');
     return {
@@ -275,7 +275,7 @@ function parseRange(range: string): { sheetName: string | null; a1Range: string 
  * Resolves a sheet name to a numeric sheet ID.
  * If sheetName is null/undefined, returns the first sheet's ID.
  */
-async function resolveSheetId(
+export async function resolveSheetId(
   sheets: Sheets,
   spreadsheetId: string,
   sheetName?: string | null
@@ -301,7 +301,7 @@ async function resolveSheetId(
  * Converts column letters to a 0-based column index.
  * Example: "A" -> 0, "B" -> 1, "Z" -> 25, "AA" -> 26
  */
-function colLettersToIndex(col: string): number {
+export function colLettersToIndex(col: string): number {
   let index = 0;
   const upper = col.toUpperCase();
   for (let i = 0; i < upper.length; i++) {
@@ -320,7 +320,7 @@ function colLettersToIndex(col: string): number {
  * start/end index is left out of the GridRange, which the Sheets API
  * interprets as "unbounded" (i.e., the entire row or column).
  */
-function parseA1ToGridRange(a1Range: string, sheetId: number): sheets_v4.Schema$GridRange {
+export function parseA1ToGridRange(a1Range: string, sheetId: number): sheets_v4.Schema$GridRange {
   // Whole-row pattern: "1:3" or "1"
   const rowOnlyMatch = a1Range.match(/^(\d+)(?::(\d+))?$/);
   if (rowOnlyMatch) {

--- a/src/tools/sheets/batchWrite.ts
+++ b/src/tools/sheets/batchWrite.ts
@@ -1,0 +1,77 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'batchWrite',
+    description:
+      'Writes data to multiple ranges in a single API call. More efficient than multiple separate writeSpreadsheet calls when updating several ranges at once.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      data: z
+        .array(
+          z.object({
+            range: z.string().describe('A1 notation range (e.g., "Sheet1!A1:B2").'),
+            values: z
+              .array(z.array(z.any()))
+              .describe('2D array of values to write. Each inner array represents a row.'),
+          })
+        )
+        .min(1)
+        .describe('Array of range+values pairs to write in a single batch.'),
+      valueInputOption: z
+        .enum(['RAW', 'USER_ENTERED'])
+        .optional()
+        .default('USER_ENTERED')
+        .describe(
+          'How input data should be interpreted. RAW: values are stored as-is. USER_ENTERED: values are parsed as if typed by a user.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      const rangeNames = args.data.map((d) => d.range).join(', ');
+      log.info(
+        `Batch writing to ${args.data.length} range(s) in spreadsheet ${args.spreadsheetId}: ${rangeNames}`
+      );
+
+      try {
+        const response = await sheets.spreadsheets.values.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: {
+            valueInputOption: args.valueInputOption,
+            data: args.data.map((d) => ({ range: d.range, values: d.values })),
+          },
+        });
+
+        const totalCells = response.data.totalUpdatedCells || 0;
+        const totalRows = response.data.totalUpdatedRows || 0;
+        const totalColumns = response.data.totalUpdatedColumns || 0;
+        const totalSheets = response.data.totalUpdatedSheets || 0;
+
+        return `Successfully batch-wrote ${totalCells} cells (${totalRows} rows, ${totalColumns} columns) across ${totalSheets} sheet(s) in ${args.data.length} range(s).`;
+      } catch (error: any) {
+        log.error(
+          `Error batch writing to spreadsheet ${args.spreadsheetId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) {
+          throw new UserError(`Spreadsheet not found (ID: ${args.spreadsheetId}). Check the ID.`);
+        }
+        if (error.code === 403) {
+          throw new UserError(
+            `Permission denied for spreadsheet (ID: ${args.spreadsheetId}). Ensure you have write access.`
+          );
+        }
+        throw new UserError(
+          `Failed to batch write to spreadsheet: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/sheets/copyFormatting.ts
+++ b/src/tools/sheets/copyFormatting.ts
@@ -1,0 +1,81 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'copyFormatting',
+    description:
+      'Copies formatting (not values) from a source range to a destination range within the same spreadsheet. Copies bold, colors, borders, number formats, etc.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      sourceSheetName: z
+        .string()
+        .min(1)
+        .describe('Source sheet/tab name (e.g., "Sheet1").'),
+      sourceRange: z
+        .string()
+        .describe('A1 notation for the source range (e.g., "A1:D10"). Do not include the sheet name — use sourceSheetName instead.'),
+      destinationSheetName: z
+        .string()
+        .min(1)
+        .describe('Destination sheet/tab name (e.g., "Sheet2").'),
+      destinationRange: z
+        .string()
+        .describe('A1 notation for the destination range (e.g., "A1:D10"). Do not include the sheet name — use destinationSheetName instead.'),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(
+        `Copying formatting from ${args.sourceSheetName}!${args.sourceRange} to ${args.destinationSheetName}!${args.destinationRange} in spreadsheet ${args.spreadsheetId}`
+      );
+
+      try {
+        // Resolve sheet names to numeric IDs
+        const sourceSheetId = await SheetsHelpers.resolveSheetId(
+          sheets,
+          args.spreadsheetId,
+          args.sourceSheetName
+        );
+        const destSheetId = await SheetsHelpers.resolveSheetId(
+          sheets,
+          args.spreadsheetId,
+          args.destinationSheetName
+        );
+
+        // Convert A1 ranges to GridRange objects
+        const sourceGridRange = SheetsHelpers.parseA1ToGridRange(args.sourceRange, sourceSheetId);
+        const destGridRange = SheetsHelpers.parseA1ToGridRange(args.destinationRange, destSheetId);
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                copyPaste: {
+                  source: sourceGridRange,
+                  destination: destGridRange,
+                  pasteType: 'PASTE_FORMAT',
+                },
+              },
+            ],
+          },
+        });
+
+        return `Successfully copied formatting from ${args.sourceSheetName}!${args.sourceRange} to ${args.destinationSheetName}!${args.destinationRange}.`;
+      } catch (error: any) {
+        log.error(
+          `Error copying formatting in spreadsheet ${args.spreadsheetId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to copy formatting: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/index.ts
+++ b/src/tools/sheets/index.ts
@@ -1,6 +1,7 @@
 import type { FastMCP } from 'fastmcp';
 import { register as readSpreadsheet } from './readSpreadsheet.js';
 import { register as writeSpreadsheet } from './writeSpreadsheet.js';
+import { register as batchWrite } from './batchWrite.js';
 import { register as appendSpreadsheetRows } from './appendSpreadsheetRows.js';
 import { register as clearSpreadsheetRange } from './clearSpreadsheetRange.js';
 import { register as getSpreadsheetInfo } from './getSpreadsheetInfo.js';
@@ -10,12 +11,15 @@ import { register as listGoogleSheets } from './listGoogleSheets.js';
 
 // Formatting & validation
 import { register as formatCells } from './formatCells.js';
+import { register as readCellFormat } from './readCellFormat.js';
+import { register as copyFormatting } from './copyFormatting.js';
 import { register as freezeRowsAndColumns } from './freezeRowsAndColumns.js';
 import { register as setDropdownValidation } from './setDropdownValidation.js';
 
 export function registerSheetsTools(server: FastMCP) {
   readSpreadsheet(server);
   writeSpreadsheet(server);
+  batchWrite(server);
   appendSpreadsheetRows(server);
   clearSpreadsheetRange(server);
   getSpreadsheetInfo(server);
@@ -25,6 +29,8 @@ export function registerSheetsTools(server: FastMCP) {
 
   // Formatting & validation
   formatCells(server);
+  readCellFormat(server);
+  copyFormatting(server);
   freezeRowsAndColumns(server);
   setDropdownValidation(server);
 }

--- a/src/tools/sheets/readCellFormat.ts
+++ b/src/tools/sheets/readCellFormat.ts
@@ -1,0 +1,153 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import { rowColToA1 } from '../../googleSheetsApiHelpers.js';
+
+/**
+ * Converts a Google Sheets RGBA color object (0-1 range) to a hex string.
+ * Returns null if the color is undefined or has no meaningful channels.
+ */
+function rgbaToHex(
+  color: { red?: number | null; green?: number | null; blue?: number | null } | null | undefined
+): string | null {
+  if (!color) return null;
+  const r = Math.round((color.red ?? 0) * 255);
+  const g = Math.round((color.green ?? 0) * 255);
+  const b = Math.round((color.blue ?? 0) * 255);
+  return `#${r.toString(16).padStart(2, '0').toUpperCase()}${g.toString(16).padStart(2, '0').toUpperCase()}${b.toString(16).padStart(2, '0').toUpperCase()}`;
+}
+
+/**
+ * Extracts a simplified formatting summary from a Google Sheets CellFormat object.
+ * Only includes properties that are explicitly set (non-default).
+ */
+function simplifyFormat(fmt: any): Record<string, any> | null {
+  if (!fmt) return null;
+  const result: Record<string, any> = {};
+
+  // Text formatting
+  if (fmt.textFormat) {
+    const tf: Record<string, any> = {};
+    if (fmt.textFormat.bold) tf.bold = true;
+    if (fmt.textFormat.italic) tf.italic = true;
+    if (fmt.textFormat.strikethrough) tf.strikethrough = true;
+    if (fmt.textFormat.underline) tf.underline = true;
+    if (fmt.textFormat.fontSize != null) tf.fontSize = fmt.textFormat.fontSize;
+    if (fmt.textFormat.fontFamily) tf.fontFamily = fmt.textFormat.fontFamily;
+    if (fmt.textFormat.foregroundColorStyle?.rgbColor) {
+      tf.foregroundColor = rgbaToHex(fmt.textFormat.foregroundColorStyle.rgbColor);
+    } else if (fmt.textFormat.foregroundColor) {
+      tf.foregroundColor = rgbaToHex(fmt.textFormat.foregroundColor);
+    }
+    if (Object.keys(tf).length > 0) result.textFormat = tf;
+  }
+
+  // Background color
+  if (fmt.backgroundColorStyle?.rgbColor) {
+    result.backgroundColor = rgbaToHex(fmt.backgroundColorStyle.rgbColor);
+  } else if (fmt.backgroundColor) {
+    result.backgroundColor = rgbaToHex(fmt.backgroundColor);
+  }
+
+  // Alignment
+  if (fmt.horizontalAlignment) result.horizontalAlignment = fmt.horizontalAlignment;
+  if (fmt.verticalAlignment) result.verticalAlignment = fmt.verticalAlignment;
+
+  // Number format
+  if (fmt.numberFormat) {
+    result.numberFormat = {
+      type: fmt.numberFormat.type,
+      pattern: fmt.numberFormat.pattern,
+    };
+  }
+
+  // Borders
+  if (fmt.borders) {
+    const borders: Record<string, any> = {};
+    for (const side of ['top', 'bottom', 'left', 'right'] as const) {
+      if (fmt.borders[side]) {
+        borders[side] = {
+          style: fmt.borders[side].style,
+          ...(fmt.borders[side].colorStyle?.rgbColor
+            ? { color: rgbaToHex(fmt.borders[side].colorStyle.rgbColor) }
+            : fmt.borders[side].color
+              ? { color: rgbaToHex(fmt.borders[side].color) }
+              : {}),
+        };
+      }
+    }
+    if (Object.keys(borders).length > 0) result.borders = borders;
+  }
+
+  // Wrap strategy
+  if (fmt.wrapStrategy) result.wrapStrategy = fmt.wrapStrategy;
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'readCellFormat',
+    description:
+      'Reads the formatting/style of cells in a given range. Returns formatting details like bold, italic, fontSize, fontFamily, colors, alignment, borders, and number format per cell.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      range: z
+        .string()
+        .describe('A1 notation range to read formatting from (e.g., "Sheet1!A1:D5" or "A1:B2").'),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(
+        `Reading cell format for range "${args.range}" in spreadsheet ${args.spreadsheetId}`
+      );
+
+      try {
+        const response = await sheets.spreadsheets.get({
+          spreadsheetId: args.spreadsheetId,
+          ranges: [args.range],
+          includeGridData: true,
+          fields:
+            'sheets.data.rowData.values.userEnteredFormat,sheets.data.startRow,sheets.data.startColumn',
+        });
+
+        const sheetData = response.data.sheets?.[0]?.data?.[0];
+        if (!sheetData?.rowData) {
+          return JSON.stringify({ range: args.range, cells: [] }, null, 2);
+        }
+
+        const startRow = sheetData.startRow ?? 0;
+        const startCol = sheetData.startColumn ?? 0;
+
+        const cells: Array<{ cell: string; format: Record<string, any> }> = [];
+
+        for (let rowIdx = 0; rowIdx < sheetData.rowData.length; rowIdx++) {
+          const row = sheetData.rowData[rowIdx];
+          if (!row.values) continue;
+
+          for (let colIdx = 0; colIdx < row.values.length; colIdx++) {
+            const cellData = row.values[colIdx];
+            const fmt = simplifyFormat(cellData?.userEnteredFormat);
+            if (fmt) {
+              const cellRef = rowColToA1(startRow + rowIdx, startCol + colIdx);
+              cells.push({ cell: cellRef, format: fmt });
+            }
+          }
+        }
+
+        return JSON.stringify({ range: args.range, cells }, null, 2);
+      } catch (error: any) {
+        log.error(
+          `Error reading cell format for spreadsheet ${args.spreadsheetId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to read cell format: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Three new tools for advanced spreadsheet operations:

- **readCellFormat** — Reads cell formatting from a range using `spreadsheets.get` with `includeGridData`
- **copyFormatting** — Copies formatting between ranges using `CopyPasteRequest` with `PASTE_FORMAT`
- **batchWrite** — Writes multiple ranges in a single call via `values.batchUpdate`

Closes #69

## Changes

- **New:** `src/tools/sheets/readCellFormat.ts`
- **New:** `src/tools/sheets/copyFormatting.ts`
- **New:** `src/tools/sheets/batchWrite.ts`
- **Modified:** `src/tools/sheets/index.ts` — Added imports and registrations
- **Modified:** `src/googleSheetsApiHelpers.ts` — Exported 4 previously private helpers (`parseRange`, `resolveSheetId`, `colLettersToIndex`, `parseA1ToGridRange`) with no signature changes

## Testing

All three tools tested against a live Google Sheets spreadsheet:
- `readCellFormat`: correctly returns bold, colors, font info for formatted cells
- `copyFormatting`: copies header styles across sheets
- `batchWrite`: writes multiple ranges in one call, verified with readback
- Build passes (`tsc` with zero errors)