### PR TITLE
feat: add renameTab tool for renaming document tabs

### DIFF
--- a/src/tools/docs/index.ts
+++ b/src/tools/docs/index.ts
@@ -3,6 +3,7 @@ import type { FastMCP } from 'fastmcp';
 // Core read/write
 import { register as readGoogleDoc } from './readGoogleDoc.js';
 import { register as listDocumentTabs } from './listDocumentTabs.js';
+import { register as renameTab } from './renameTab.js';
 import { register as appendToGoogleDoc } from './appendToGoogleDoc.js';
 import { register as insertText } from './insertText.js';
 import { register as deleteRange } from './deleteRange.js';
@@ -20,6 +21,7 @@ export function registerDocsTools(server: FastMCP) {
   // Core read/write
   readGoogleDoc(server);
   listDocumentTabs(server);
+  renameTab(server);
   appendToGoogleDoc(server);
   insertText(server);
   deleteRange(server);

--- a/src/tools/docs/renameTab.ts
+++ b/src/tools/docs/renameTab.ts
@@ -1,0 +1,68 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'renameTab',
+    description:
+      'Renames a tab in a Google Docs document. Use listDocumentTabs to get tab IDs first.',
+    parameters: DocumentIdParameter.extend({
+      tabId: z
+        .string()
+        .describe('The ID of the tab to rename. Use listDocumentTabs to get tab IDs.'),
+      newTitle: z.string().min(1).describe('The new title for the tab.'),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+
+      log.info(`Renaming tab ${args.tabId} to "${args.newTitle}" in doc ${args.documentId}`);
+
+      try {
+        // Verify the tab exists
+        const docInfo = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields: 'tabs(tabProperties,documentTab)',
+        });
+        const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
+        if (!targetTab) {
+          throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
+        }
+
+        const oldTitle = targetTab.tabProperties?.title || '(untitled)';
+
+        await docs.documents.batchUpdate({
+          documentId: args.documentId,
+          requestBody: {
+            requests: [
+              {
+                updateDocumentTabProperties: {
+                  tabProperties: {
+                    tabId: args.tabId,
+                    title: args.newTitle,
+                  },
+                  fields: 'title',
+                },
+              },
+            ],
+          },
+        });
+
+        return `Successfully renamed tab from "${oldTitle}" to "${args.newTitle}".`;
+      } catch (error: any) {
+        log.error(
+          `Error renaming tab ${args.tabId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(`Failed to rename tab: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adds a new `renameTab` tool that renames a tab in a Google Docs document using the `updateDocumentTabProperties` API. Verifies the tab exists before attempting the rename and returns the old and new title on success.

## Changes

- **New:** `src/tools/docs/renameTab.ts` — Tool implementation using `batchUpdate` with `updateDocumentTabProperties`.
- **Modified:** `src/tools/docs/index.ts` — Added import and registration.

## Parameters

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `documentId` | string | Yes | The document ID |
| `tabId` | string | Yes | The ID of the tab to rename (use `listDocumentTabs` to get tab IDs) |
| `newTitle` | string | Yes | The new title for the tab |

## Testing

- Build passes (`tsc` with zero errors).
- Prettier formatting passes.
- All existing 107 tests continue to pass.