### PR TITLE
feat(sheets): add 7 new tools and extend formatCells with verticalAlignment & wrapStrategy

### DIFF
--- a/src/googleSheetsApiHelpers.ts
+++ b/src/googleSheetsApiHelpers.ts
@@ -389,6 +389,7 @@ export async function formatCells(
     };
     horizontalAlignment?: 'LEFT' | 'CENTER' | 'RIGHT';
     verticalAlignment?: 'TOP' | 'MIDDLE' | 'BOTTOM';
+    wrapStrategy?: 'OVERFLOW_CELL' | 'CLIP' | 'WRAP';
     numberFormat?: { type: string; pattern?: string };
   }
 ): Promise<sheets_v4.Schema$BatchUpdateSpreadsheetResponse> {
@@ -441,6 +442,10 @@ export async function formatCells(
       userEnteredFormat.verticalAlignment = format.verticalAlignment;
     }
 
+    if (format.wrapStrategy) {
+      userEnteredFormat.wrapStrategy = format.wrapStrategy;
+    }
+
     if (format.numberFormat) {
       userEnteredFormat.numberFormat = {
         type: format.numberFormat.type,
@@ -453,6 +458,7 @@ export async function formatCells(
       'textFormat',
       'horizontalAlignment',
       'verticalAlignment',
+      'wrapStrategy',
       ...(format.numberFormat ? ['numberFormat'] : []),
     ].join(',');
 

--- a/src/tools/sheets/autoResizeRows.ts
+++ b/src/tools/sheets/autoResizeRows.ts
@@ -33,10 +33,9 @@ export function register(server: FastMCP) {
           .optional()
           .describe('1-based end row index (inclusive). Omit to resize to the last row.'),
       })
-      .refine(
-        (d) => d.startRow === undefined || d.endRow === undefined || d.endRow >= d.startRow,
-        { message: 'endRow must be greater than or equal to startRow.' }
-      ),
+      .refine((d) => d.startRow === undefined || d.endRow === undefined || d.endRow >= d.startRow, {
+        message: 'endRow must be greater than or equal to startRow.',
+      }),
     execute: async (args, { log }) => {
       const sheets = await getSheetsClient();
       log.info(`Auto-resizing rows in spreadsheet ${args.spreadsheetId}`);
@@ -60,7 +59,9 @@ export function register(server: FastMCP) {
         });
 
         const rangeDesc =
-          args.startRow !== undefined ? `rows ${args.startRow}–${args.endRow ?? 'end'}` : 'all rows';
+          args.startRow !== undefined
+            ? `rows ${args.startRow}–${args.endRow ?? 'end'}`
+            : 'all rows';
         return `Successfully auto-resized ${rangeDesc} to fit content.`;
       } catch (error: any) {
         log.error(`Error auto-resizing rows: ${error.message || error}`);

--- a/src/tools/sheets/autoResizeRows.ts
+++ b/src/tools/sheets/autoResizeRows.ts
@@ -1,0 +1,72 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'autoResizeRows',
+    description:
+      'Auto-resizes rows in a spreadsheet to fit their content. Optionally restrict to a row range (e.g., startRow=2, endRow=50); defaults to all rows.',
+    parameters: z
+      .object({
+        spreadsheetId: z
+          .string()
+          .describe(
+            'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+          ),
+        sheetName: z
+          .string()
+          .optional()
+          .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
+        startRow: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe('1-based start row index (inclusive). Omit to start from row 1.'),
+        endRow: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe('1-based end row index (inclusive). Omit to resize to the last row.'),
+      })
+      .refine(
+        (d) => d.startRow === undefined || d.endRow === undefined || d.endRow >= d.startRow,
+        { message: 'endRow must be greater than or equal to startRow.' }
+      ),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Auto-resizing rows in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const sheetId = await SheetsHelpers.resolveSheetId(
+          sheets,
+          args.spreadsheetId,
+          args.sheetName
+        );
+
+        const dimensionRange: any = { sheetId, dimension: 'ROWS' };
+        if (args.startRow !== undefined) dimensionRange.startIndex = args.startRow - 1;
+        if (args.endRow !== undefined) dimensionRange.endIndex = args.endRow;
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: {
+            requests: [{ autoResizeDimensions: { dimensions: dimensionRange } }],
+          },
+        });
+
+        const rangeDesc =
+          args.startRow !== undefined ? `rows ${args.startRow}–${args.endRow ?? 'end'}` : 'all rows';
+        return `Successfully auto-resized ${rangeDesc} to fit content.`;
+      } catch (error: any) {
+        log.error(`Error auto-resizing rows: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to auto-resize rows: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/copySheetTo.ts
+++ b/src/tools/sheets/copySheetTo.ts
@@ -14,9 +14,7 @@ export function register(server: FastMCP) {
         .number()
         .int()
         .describe('The numeric sheet ID to copy. Use getSpreadsheetInfo to find sheet IDs.'),
-      destinationSpreadsheetId: z
-        .string()
-        .describe('The spreadsheet ID of the destination file.'),
+      destinationSpreadsheetId: z.string().describe('The spreadsheet ID of the destination file.'),
     }),
     execute: async (args, { log }) => {
       const sheets = await getSheetsClient();

--- a/src/tools/sheets/copySheetTo.ts
+++ b/src/tools/sheets/copySheetTo.ts
@@ -1,0 +1,43 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'copySheetTo',
+    description:
+      'Copies a sheet (tab) from one spreadsheet to another spreadsheet. Use getSpreadsheetInfo to find the numeric sheet ID. The copied sheet will be appended to the destination spreadsheet.',
+    parameters: z.object({
+      sourceSpreadsheetId: z.string().describe('The spreadsheet ID of the source file.'),
+      sheetId: z
+        .number()
+        .int()
+        .describe('The numeric sheet ID to copy. Use getSpreadsheetInfo to find sheet IDs.'),
+      destinationSpreadsheetId: z
+        .string()
+        .describe('The spreadsheet ID of the destination file.'),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(
+        `Copying sheet ${args.sheetId} from ${args.sourceSpreadsheetId} to ${args.destinationSpreadsheetId}`
+      );
+
+      try {
+        const response = await sheets.spreadsheets.sheets.copyTo({
+          spreadsheetId: args.sourceSpreadsheetId,
+          sheetId: args.sheetId,
+          requestBody: { destinationSpreadsheetId: args.destinationSpreadsheetId },
+        });
+
+        const props = response.data;
+        return `Successfully copied sheet to destination as "${props.title}" (Sheet ID: ${props.sheetId}).`;
+      } catch (error: any) {
+        log.error(`Error copying sheet: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to copy sheet: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/deleteConditionalFormatting.ts
+++ b/src/tools/sheets/deleteConditionalFormatting.ts
@@ -1,0 +1,62 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'deleteConditionalFormatting',
+    description:
+      'Deletes one or more conditional formatting rules from a sheet by their index. Use getConditionalFormatting to list existing rules and their indices.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      sheetName: z
+        .string()
+        .optional()
+        .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
+      ruleIndices: z
+        .array(z.number().int().min(0))
+        .min(1)
+        .describe(
+          'Array of rule indices to delete (0-based, from getConditionalFormatting). Order does not matter — the tool sorts automatically.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Deleting conditional formatting rules from spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const sheetId = await SheetsHelpers.resolveSheetId(
+          sheets,
+          args.spreadsheetId,
+          args.sheetName
+        );
+
+        // Sort descending to avoid index shifting during batch delete
+        const indices = [...args.ruleIndices].sort((a, b) => b - a);
+
+        const requests = indices.map((index) => ({
+          deleteConditionalFormatRule: { sheetId, index },
+        }));
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: { requests },
+        });
+
+        return `Successfully deleted ${indices.length} conditional formatting rule(s) at indices: ${args.ruleIndices.join(', ')}.`;
+      } catch (error: any) {
+        log.error(`Error deleting conditional formatting: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Failed to delete conditional formatting: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/sheets/formatCells.ts
+++ b/src/tools/sheets/formatCells.ts
@@ -33,6 +33,16 @@ export function register(server: FastMCP) {
           .enum(['LEFT', 'CENTER', 'RIGHT'])
           .optional()
           .describe('Horizontal text alignment.'),
+        verticalAlignment: z
+          .enum(['TOP', 'MIDDLE', 'BOTTOM'])
+          .optional()
+          .describe('Vertical text alignment within the cell.'),
+        wrapStrategy: z
+          .enum(['OVERFLOW_CELL', 'CLIP', 'WRAP'])
+          .optional()
+          .describe(
+            'Text wrap strategy: WRAP wraps to multiple lines, CLIP truncates, OVERFLOW_CELL overflows into adjacent cells.'
+          ),
         numberFormat: z
           .object({
             type: z
@@ -69,6 +79,8 @@ export function register(server: FastMCP) {
           data.foregroundColor !== undefined ||
           data.backgroundColor !== undefined ||
           data.horizontalAlignment !== undefined ||
+          data.verticalAlignment !== undefined ||
+          data.wrapStrategy !== undefined ||
           data.numberFormat !== undefined,
         { message: 'At least one formatting option must be provided.' }
       ),
@@ -106,6 +118,14 @@ export function register(server: FastMCP) {
 
         if (args.horizontalAlignment) {
           format.horizontalAlignment = args.horizontalAlignment;
+        }
+
+        if (args.verticalAlignment) {
+          format.verticalAlignment = args.verticalAlignment;
+        }
+
+        if (args.wrapStrategy) {
+          (format as any).wrapStrategy = args.wrapStrategy;
         }
 
         if (args.numberFormat) {

--- a/src/tools/sheets/getConditionalFormatting.ts
+++ b/src/tools/sheets/getConditionalFormatting.ts
@@ -68,8 +68,7 @@ export function register(server: FastMCP) {
           const ranges = (rule.ranges ?? []).map((r) => {
             const startCol =
               r.startColumnIndex != null ? colIndexToLetters(r.startColumnIndex) : '';
-            const endCol =
-              r.endColumnIndex != null ? colIndexToLetters(r.endColumnIndex - 1) : '';
+            const endCol = r.endColumnIndex != null ? colIndexToLetters(r.endColumnIndex - 1) : '';
             const startRow = r.startRowIndex != null ? r.startRowIndex + 1 : '';
             const endRow = r.endRowIndex != null ? r.endRowIndex : '';
             return `${startCol}${startRow}:${endCol}${endRow}`;
@@ -80,9 +79,13 @@ export function register(server: FastMCP) {
             .map((v: any) => v.userEnteredValue)
             .join(', ');
           const bg = fmt.backgroundColor;
-          const bgColor = bg ? rgbToHex({ red: bg.red ?? 0, green: bg.green ?? 0, blue: bg.blue ?? 0 }) : null;
+          const bgColor = bg
+            ? rgbToHex({ red: bg.red ?? 0, green: bg.green ?? 0, blue: bg.blue ?? 0 })
+            : null;
           const fg = fmt.textFormat?.foregroundColor;
-          const fgColor = fg ? rgbToHex({ red: fg.red ?? 0, green: fg.green ?? 0, blue: fg.blue ?? 0 }) : null;
+          const fgColor = fg
+            ? rgbToHex({ red: fg.red ?? 0, green: fg.green ?? 0, blue: fg.blue ?? 0 })
+            : null;
 
           return [
             `[Rule ${idx}]`,

--- a/src/tools/sheets/getConditionalFormatting.ts
+++ b/src/tools/sheets/getConditionalFormatting.ts
@@ -1,0 +1,109 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+function colIndexToLetters(index: number): string {
+  let s = '';
+  let i = index;
+  do {
+    s = String.fromCharCode(65 + (i % 26)) + s;
+    i = Math.floor(i / 26) - 1;
+  } while (i >= 0);
+  return s;
+}
+
+function rgbToHex(rgb: { red?: number; green?: number; blue?: number } | null | undefined): string {
+  if (!rgb) return '#000000';
+  const r = Math.round((rgb.red ?? 0) * 255);
+  const g = Math.round((rgb.green ?? 0) * 255);
+  const b = Math.round((rgb.blue ?? 0) * 255);
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`.toUpperCase();
+}
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'getConditionalFormatting',
+    description:
+      'Lists all conditional formatting rules for a sheet, including their index (needed for deleteConditionalFormatting), condition, ranges, and applied formats.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      sheetName: z
+        .string()
+        .optional()
+        .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Getting conditional formatting rules for spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const sheetId = await SheetsHelpers.resolveSheetId(
+          sheets,
+          args.spreadsheetId,
+          args.sheetName
+        );
+
+        const response = await sheets.spreadsheets.get({
+          spreadsheetId: args.spreadsheetId,
+          fields: 'sheets(properties(sheetId,title),conditionalFormats)',
+        });
+
+        const sheet = response.data.sheets?.find((s) => s.properties?.sheetId === sheetId);
+        const rules = sheet?.conditionalFormats ?? [];
+
+        if (rules.length === 0) {
+          return 'No conditional formatting rules found on this sheet.';
+        }
+
+        const summary = rules.map((rule, idx) => {
+          const condition = rule.booleanRule?.condition ?? rule.gradientRule;
+          const fmt = rule.booleanRule?.format ?? {};
+
+          const ranges = (rule.ranges ?? []).map((r) => {
+            const startCol =
+              r.startColumnIndex != null ? colIndexToLetters(r.startColumnIndex) : '';
+            const endCol =
+              r.endColumnIndex != null ? colIndexToLetters(r.endColumnIndex - 1) : '';
+            const startRow = r.startRowIndex != null ? r.startRowIndex + 1 : '';
+            const endRow = r.endRowIndex != null ? r.endRowIndex : '';
+            return `${startCol}${startRow}:${endCol}${endRow}`;
+          });
+
+          const condType = (condition as any)?.type ?? 'GRADIENT';
+          const condValues = ((condition as any)?.values ?? [])
+            .map((v: any) => v.userEnteredValue)
+            .join(', ');
+          const bg = fmt.backgroundColor;
+          const bgColor = bg ? rgbToHex({ red: bg.red ?? 0, green: bg.green ?? 0, blue: bg.blue ?? 0 }) : null;
+          const fg = fmt.textFormat?.foregroundColor;
+          const fgColor = fg ? rgbToHex({ red: fg.red ?? 0, green: fg.green ?? 0, blue: fg.blue ?? 0 }) : null;
+
+          return [
+            `[Rule ${idx}]`,
+            `  Ranges: ${ranges.join(', ')}`,
+            `  Condition: ${condType}${condValues ? ` = ${condValues}` : ''}`,
+            bgColor ? `  Background: ${bgColor}` : null,
+            fgColor ? `  Text color: ${fgColor}` : null,
+            fmt.textFormat?.bold ? '  Bold: true' : null,
+          ]
+            .filter(Boolean)
+            .join('\n');
+        });
+
+        return `Found ${rules.length} conditional formatting rule(s):\n\n${summary.join('\n\n')}`;
+      } catch (error: any) {
+        log.error(`Error getting conditional formatting: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Failed to get conditional formatting: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/sheets/index.ts
+++ b/src/tools/sheets/index.ts
@@ -11,6 +11,7 @@ import { register as listGoogleSheets } from './listGoogleSheets.js';
 import { register as deleteSheet } from './deleteSheet.js';
 import { register as renameSheet } from './renameSheet.js';
 import { register as duplicateSheet } from './duplicateSheet.js';
+import { register as copySheetTo } from './copySheetTo.js';
 
 // Formatting & validation
 import { register as formatCells } from './formatCells.js';
@@ -19,6 +20,12 @@ import { register as copyFormatting } from './copyFormatting.js';
 import { register as freezeRowsAndColumns } from './freezeRowsAndColumns.js';
 import { register as setColumnWidths } from './setColumnWidths.js';
 import { register as autoResizeColumns } from './autoResizeColumns.js';
+import { register as autoResizeRows } from './autoResizeRows.js';
+import { register as setRowHeights } from './setRowHeights.js';
+import { register as setCellBorders } from './setCellBorders.js';
+import { register as protectRange } from './protectRange.js';
+import { register as getConditionalFormatting } from './getConditionalFormatting.js';
+import { register as deleteConditionalFormatting } from './deleteConditionalFormatting.js';
 import { register as setDropdownValidation } from './setDropdownValidation.js';
 import { register as addConditionalFormatting } from './addConditionalFormatting.js';
 import { register as groupRows } from './groupRows.js';
@@ -47,6 +54,7 @@ export function registerSheetsTools(server: FastMCP) {
   deleteSheet(server);
   renameSheet(server);
   duplicateSheet(server);
+  copySheetTo(server);
 
   // Formatting & validation
   formatCells(server);
@@ -55,6 +63,12 @@ export function registerSheetsTools(server: FastMCP) {
   freezeRowsAndColumns(server);
   setColumnWidths(server);
   autoResizeColumns(server);
+  autoResizeRows(server);
+  setRowHeights(server);
+  setCellBorders(server);
+  protectRange(server);
+  getConditionalFormatting(server);
+  deleteConditionalFormatting(server);
   setDropdownValidation(server);
   addConditionalFormatting(server);
   groupRows(server);

--- a/src/tools/sheets/protectRange.ts
+++ b/src/tools/sheets/protectRange.ts
@@ -1,0 +1,81 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'protectRange',
+    description:
+      "Locks (protects) a range or an entire sheet to prevent accidental edits. Optionally specify a description. The protection applies to the authenticated user's account.",
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      sheetName: z
+        .string()
+        .optional()
+        .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
+      range: z
+        .string()
+        .optional()
+        .describe(
+          'A1 notation range to protect (e.g., "A1:D10", "1:1"). Omit to protect the entire sheet.'
+        ),
+      description: z
+        .string()
+        .optional()
+        .describe(
+          'Human-readable description for this protection (e.g., "Header row — do not edit").'
+        ),
+      warningOnly: z
+        .boolean()
+        .optional()
+        .describe(
+          'If true, shows a warning when editing but does not block it. Defaults to false (fully locked).'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Protecting range in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const sheetId = await SheetsHelpers.resolveSheetId(
+          sheets,
+          args.spreadsheetId,
+          args.sheetName
+        );
+
+        const protectedRange: any = {
+          description: args.description ?? '',
+          warningOnly: args.warningOnly ?? false,
+        };
+
+        if (args.range) {
+          protectedRange.range = SheetsHelpers.parseA1ToGridRange(args.range, sheetId);
+        } else {
+          protectedRange.sheetId = sheetId;
+        }
+
+        const response = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: {
+            requests: [{ addProtectedRange: { protectedRange } }],
+          },
+        });
+
+        const result = response.data.replies?.[0]?.addProtectedRange?.protectedRange;
+        const target = args.range ? `range "${args.range}"` : 'entire sheet';
+        const mode = args.warningOnly ? 'warning-only' : 'fully locked';
+        return `Successfully protected ${target} (Protection ID: ${result?.protectedRangeId}, mode: ${mode}).`;
+      } catch (error: any) {
+        log.error(`Error protecting range: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to protect range: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/setCellBorders.ts
+++ b/src/tools/sheets/setCellBorders.ts
@@ -36,9 +36,7 @@ export function register(server: FastMCP) {
           .describe(
             'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
           ),
-        range: z
-          .string()
-          .describe('A1 notation range (e.g., "Sheet1!A1:D10", "1:1", "A:A").'),
+        range: z.string().describe('A1 notation range (e.g., "Sheet1!A1:D10", "1:1", "A:A").'),
         top: borderSchema.describe('Top border of the range.'),
         bottom: borderSchema.describe('Bottom border of the range.'),
         left: borderSchema.describe('Left border of the range.'),

--- a/src/tools/sheets/setCellBorders.ts
+++ b/src/tools/sheets/setCellBorders.ts
@@ -1,0 +1,104 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+const borderStyleEnum = z.enum([
+  'SOLID',
+  'SOLID_MEDIUM',
+  'SOLID_THICK',
+  'DOTTED',
+  'DASHED',
+  'DOUBLE',
+  'NONE',
+]);
+
+const borderSchema = z
+  .object({
+    style: borderStyleEnum.describe('Border line style.'),
+    color: z
+      .string()
+      .optional()
+      .describe('Border color as hex (e.g., "#000000"). Defaults to black.'),
+  })
+  .optional();
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'setCellBorders',
+    description:
+      'Sets borders on a range of cells. Each side (top, bottom, left, right, innerHorizontal, innerVertical) can be configured independently with a style and color. Use style "NONE" to remove a border.',
+    parameters: z
+      .object({
+        spreadsheetId: z
+          .string()
+          .describe(
+            'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+          ),
+        range: z
+          .string()
+          .describe('A1 notation range (e.g., "Sheet1!A1:D10", "1:1", "A:A").'),
+        top: borderSchema.describe('Top border of the range.'),
+        bottom: borderSchema.describe('Bottom border of the range.'),
+        left: borderSchema.describe('Left border of the range.'),
+        right: borderSchema.describe('Right border of the range.'),
+        innerHorizontal: borderSchema.describe('Horizontal borders between rows inside the range.'),
+        innerVertical: borderSchema.describe('Vertical borders between columns inside the range.'),
+      })
+      .refine(
+        (d) =>
+          d.top !== undefined ||
+          d.bottom !== undefined ||
+          d.left !== undefined ||
+          d.right !== undefined ||
+          d.innerHorizontal !== undefined ||
+          d.innerVertical !== undefined,
+        { message: 'At least one border side must be specified.' }
+      ),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Setting borders on range "${args.range}" in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const { sheetName, a1Range } = SheetsHelpers.parseRange(args.range);
+        const sheetId = await SheetsHelpers.resolveSheetId(sheets, args.spreadsheetId, sheetName);
+        const gridRange = SheetsHelpers.parseA1ToGridRange(a1Range, sheetId);
+
+        const buildBorder = (b: { style: string; color?: string } | undefined) => {
+          if (!b) return undefined;
+          const border: any = { style: b.style };
+          if (b.color) {
+            const rgb = SheetsHelpers.hexToRgb(b.color);
+            if (!rgb) throw new UserError(`Invalid border color: "${b.color}".`);
+            border.colorStyle = { rgbColor: rgb };
+          }
+          return border;
+        };
+
+        const borders: any = {};
+        if (args.top !== undefined) borders.top = buildBorder(args.top);
+        if (args.bottom !== undefined) borders.bottom = buildBorder(args.bottom);
+        if (args.left !== undefined) borders.left = buildBorder(args.left);
+        if (args.right !== undefined) borders.right = buildBorder(args.right);
+        if (args.innerHorizontal !== undefined)
+          borders.innerHorizontal = buildBorder(args.innerHorizontal);
+        if (args.innerVertical !== undefined)
+          borders.innerVertical = buildBorder(args.innerVertical);
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: {
+            requests: [{ updateBorders: { range: gridRange, ...borders } }],
+          },
+        });
+
+        return `Successfully set borders on range "${args.range}".`;
+      } catch (error: any) {
+        log.error(`Error setting borders: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to set borders: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/setRowHeights.ts
+++ b/src/tools/sheets/setRowHeights.ts
@@ -1,0 +1,83 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'setRowHeights',
+    description:
+      'Sets a fixed pixel height for a range of rows in a spreadsheet. Useful for ensuring rows are tall enough to display wrapped text.',
+    parameters: z
+      .object({
+        spreadsheetId: z
+          .string()
+          .describe(
+            'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+          ),
+        sheetName: z
+          .string()
+          .optional()
+          .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
+        startRow: z
+          .number()
+          .int()
+          .min(1)
+          .describe('1-based start row index (inclusive).'),
+        endRow: z
+          .number()
+          .int()
+          .min(1)
+          .describe('1-based end row index (inclusive).'),
+        pixelSize: z
+          .number()
+          .int()
+          .min(2)
+          .describe(
+            'Height in pixels (e.g., 40 for comfortable single-line, 80 for two-line wrapped text).'
+          ),
+      })
+      .refine((d) => d.endRow >= d.startRow, {
+        message: 'endRow must be greater than or equal to startRow.',
+      }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Setting row heights in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const sheetId = await SheetsHelpers.resolveSheetId(
+          sheets,
+          args.spreadsheetId,
+          args.sheetName
+        );
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId: args.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                updateDimensionProperties: {
+                  range: {
+                    sheetId,
+                    dimension: 'ROWS',
+                    startIndex: args.startRow - 1,
+                    endIndex: args.endRow,
+                  },
+                  properties: { pixelSize: args.pixelSize },
+                  fields: 'pixelSize',
+                },
+              },
+            ],
+          },
+        });
+
+        return `Successfully set rows ${args.startRow}–${args.endRow} to ${args.pixelSize}px height.`;
+      } catch (error: any) {
+        log.error(`Error setting row heights: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to set row heights: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/setRowHeights.ts
+++ b/src/tools/sheets/setRowHeights.ts
@@ -20,16 +20,8 @@ export function register(server: FastMCP) {
           .string()
           .optional()
           .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
-        startRow: z
-          .number()
-          .int()
-          .min(1)
-          .describe('1-based start row index (inclusive).'),
-        endRow: z
-          .number()
-          .int()
-          .min(1)
-          .describe('1-based end row index (inclusive).'),
+        startRow: z.number().int().min(1).describe('1-based start row index (inclusive).'),
+        endRow: z.number().int().min(1).describe('1-based end row index (inclusive).'),
         pixelSize: z
           .number()
           .int()

--- a/src/tools/sheets/sheetsNewTools.test.ts
+++ b/src/tools/sheets/sheetsNewTools.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+// --- colIndexToLetters (duplicated from getConditionalFormatting for unit testing) ---
+function colIndexToLetters(index: number): string {
+  let s = '';
+  let i = index;
+  do {
+    s = String.fromCharCode(65 + (i % 26)) + s;
+    i = Math.floor(i / 26) - 1;
+  } while (i >= 0);
+  return s;
+}
+
+// --- Mocks ---
+const mockResolveSheetId = vi.fn(async () => 0);
+const mockBatchUpdate = vi.fn(async () => ({ data: { replies: [{}] } }));
+
+const mockSheets = {
+  spreadsheets: {
+    batchUpdate: mockBatchUpdate,
+    get: vi.fn(),
+  },
+};
+
+vi.mock('../../clients.js', () => ({
+  getSheetsClient: vi.fn(async () => mockSheets),
+}));
+
+vi.mock('../../googleSheetsApiHelpers.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../googleSheetsApiHelpers.js')>();
+  return {
+    ...actual,
+    resolveSheetId: mockResolveSheetId,
+    parseA1ToGridRange: vi.fn((_a1: string, sheetId: number) => ({
+      sheetId,
+      startRowIndex: 0,
+      endRowIndex: 1,
+      startColumnIndex: 0,
+      endColumnIndex: 1,
+    })),
+    parseRange: vi.fn((range: string) => {
+      const idx = range.indexOf('!');
+      return idx !== -1
+        ? { sheetName: range.slice(0, idx), a1Range: range.slice(idx + 1) }
+        : { sheetName: null, a1Range: range };
+    }),
+    hexToRgb: vi.fn((hex: string) => {
+      if (hex === '#FF0000') return { red: 1, green: 0, blue: 0 };
+      return { red: 0, green: 0, blue: 0 };
+    }),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolveSheetId.mockResolvedValue(0);
+  mockBatchUpdate.mockResolvedValue({ data: { replies: [{}] } });
+});
+
+// ============================================================
+// colIndexToLetters
+// ============================================================
+describe('colIndexToLetters', () => {
+  it('converts single-letter columns correctly', () => {
+    expect(colIndexToLetters(0)).toBe('A');
+    expect(colIndexToLetters(1)).toBe('B');
+    expect(colIndexToLetters(25)).toBe('Z');
+  });
+
+  it('converts multi-letter columns correctly (beyond Z)', () => {
+    expect(colIndexToLetters(26)).toBe('AA');
+    expect(colIndexToLetters(27)).toBe('AB');
+    expect(colIndexToLetters(51)).toBe('AZ');
+    expect(colIndexToLetters(52)).toBe('BA');
+    expect(colIndexToLetters(701)).toBe('ZZ');
+    expect(colIndexToLetters(702)).toBe('AAA');
+  });
+});
+
+// ============================================================
+// autoResizeRows — Zod validation
+// ============================================================
+describe('autoResizeRows schema validation', () => {
+  const schema = z
+    .object({
+      spreadsheetId: z.string(),
+      startRow: z.number().int().min(1).optional(),
+      endRow: z.number().int().min(1).optional(),
+    })
+    .refine((d) => d.startRow === undefined || d.endRow === undefined || d.endRow >= d.startRow, {
+      message: 'endRow must be greater than or equal to startRow.',
+    });
+
+  it('passes when startRow <= endRow', () => {
+    expect(() => schema.parse({ spreadsheetId: 'id', startRow: 2, endRow: 10 })).not.toThrow();
+  });
+
+  it('passes when only startRow provided', () => {
+    expect(() => schema.parse({ spreadsheetId: 'id', startRow: 5 })).not.toThrow();
+  });
+
+  it('passes when neither startRow nor endRow provided', () => {
+    expect(() => schema.parse({ spreadsheetId: 'id' })).not.toThrow();
+  });
+
+  it('fails when endRow < startRow', () => {
+    const result = schema.safeParse({ spreadsheetId: 'id', startRow: 10, endRow: 5 });
+    expect(result.success).toBe(false);
+  });
+
+  it('passes when startRow === endRow', () => {
+    expect(() => schema.parse({ spreadsheetId: 'id', startRow: 3, endRow: 3 })).not.toThrow();
+  });
+});
+
+// ============================================================
+// setRowHeights — Zod validation
+// ============================================================
+describe('setRowHeights schema validation', () => {
+  const schema = z
+    .object({
+      spreadsheetId: z.string(),
+      startRow: z.number().int().min(1),
+      endRow: z.number().int().min(1),
+      pixelSize: z.number().int().min(2),
+    })
+    .refine((d) => d.endRow >= d.startRow, {
+      message: 'endRow must be greater than or equal to startRow.',
+    });
+
+  it('passes with valid input', () => {
+    expect(() =>
+      schema.parse({ spreadsheetId: 'id', startRow: 1, endRow: 10, pixelSize: 40 })
+    ).not.toThrow();
+  });
+
+  it('fails when endRow < startRow', () => {
+    const result = schema.safeParse({
+      spreadsheetId: 'id',
+      startRow: 10,
+      endRow: 5,
+      pixelSize: 40,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when pixelSize < 2', () => {
+    const result = schema.safeParse({ spreadsheetId: 'id', startRow: 1, endRow: 5, pixelSize: 1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('passes when startRow === endRow', () => {
+    expect(() =>
+      schema.parse({ spreadsheetId: 'id', startRow: 5, endRow: 5, pixelSize: 40 })
+    ).not.toThrow();
+  });
+});
+
+// ============================================================
+// deleteConditionalFormatting — auto-sort descending
+// ============================================================
+describe('deleteConditionalFormatting sort order', () => {
+  it('sorts indices descending before building requests', () => {
+    const indices = [0, 3, 1];
+    const sorted = [...indices].sort((a, b) => b - a);
+    expect(sorted).toEqual([3, 1, 0]);
+  });
+
+  it('single index unchanged after sort', () => {
+    const sorted = [...[2]].sort((a, b) => b - a);
+    expect(sorted).toEqual([2]);
+  });
+
+  it('already-descending input stays correct', () => {
+    const sorted = [...[5, 3, 1, 0]].sort((a, b) => b - a);
+    expect(sorted).toEqual([5, 3, 1, 0]);
+  });
+
+  it('ascending input gets reversed', () => {
+    const sorted = [...[0, 1, 2, 3]].sort((a, b) => b - a);
+    expect(sorted).toEqual([3, 2, 1, 0]);
+  });
+});
+
+// ============================================================
+// setRowHeights — API call shape
+// ============================================================
+describe('setRowHeights API call shape', () => {
+  it('sends updateDimensionProperties with correct fields', async () => {
+    const { getSheetsClient } = await import('../../clients.js');
+    const sheets = await getSheetsClient();
+    const sheetId = await mockResolveSheetId();
+
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: 'test-id',
+      requestBody: {
+        requests: [
+          {
+            updateDimensionProperties: {
+              range: { sheetId, dimension: 'ROWS', startIndex: 1, endIndex: 5 },
+              properties: { pixelSize: 40 },
+              fields: 'pixelSize',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(mockBatchUpdate).toHaveBeenCalledOnce();
+    const req = mockBatchUpdate.mock.calls[0][0].requestBody.requests[0].updateDimensionProperties;
+    expect(req.range.dimension).toBe('ROWS');
+    expect(req.properties.pixelSize).toBe(40);
+    expect(req.fields).toBe('pixelSize');
+  });
+});
+
+// ============================================================
+// autoResizeRows — API call shape
+// ============================================================
+describe('autoResizeRows API call shape', () => {
+  it('sends autoResizeDimensions with ROWS dimension', async () => {
+    const { getSheetsClient } = await import('../../clients.js');
+    const sheets = await getSheetsClient();
+    const sheetId = await mockResolveSheetId();
+
+    const dimensionRange: any = { sheetId, dimension: 'ROWS', startIndex: 1, endIndex: 10 };
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: 'test-id',
+      requestBody: {
+        requests: [{ autoResizeDimensions: { dimensions: dimensionRange } }],
+      },
+    });
+
+    expect(mockBatchUpdate).toHaveBeenCalledOnce();
+    const dims =
+      mockBatchUpdate.mock.calls[0][0].requestBody.requests[0].autoResizeDimensions.dimensions;
+    expect(dims.dimension).toBe('ROWS');
+    expect(dims.startIndex).toBe(1);
+    expect(dims.endIndex).toBe(10);
+  });
+});
+
+// ============================================================
+// setCellBorders — Zod validation
+// ============================================================
+describe('setCellBorders schema validation', () => {
+  const borderSchema = z
+    .object({
+      style: z.enum(['SOLID', 'SOLID_MEDIUM', 'SOLID_THICK', 'DOTTED', 'DASHED', 'DOUBLE', 'NONE']),
+      color: z.string().optional(),
+    })
+    .optional();
+
+  const schema = z
+    .object({
+      spreadsheetId: z.string(),
+      range: z.string(),
+      top: borderSchema,
+      bottom: borderSchema,
+      left: borderSchema,
+      right: borderSchema,
+      innerHorizontal: borderSchema,
+      innerVertical: borderSchema,
+    })
+    .refine(
+      (d) =>
+        d.top !== undefined ||
+        d.bottom !== undefined ||
+        d.left !== undefined ||
+        d.right !== undefined ||
+        d.innerHorizontal !== undefined ||
+        d.innerVertical !== undefined,
+      { message: 'At least one border side must be specified.' }
+    );
+
+  it('passes with at least one side', () => {
+    expect(() =>
+      schema.parse({ spreadsheetId: 'id', range: 'A1:D10', top: { style: 'SOLID' } })
+    ).not.toThrow();
+  });
+
+  it('fails when no sides specified', () => {
+    const result = schema.safeParse({ spreadsheetId: 'id', range: 'A1:D10' });
+    expect(result.success).toBe(false);
+  });
+
+  it('passes with multiple sides', () => {
+    expect(() =>
+      schema.parse({
+        spreadsheetId: 'id',
+        range: 'A1:D10',
+        top: { style: 'SOLID_MEDIUM', color: '#000000' },
+        bottom: { style: 'NONE' },
+        innerHorizontal: { style: 'DOTTED' },
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects invalid border style', () => {
+    const result = schema.safeParse({
+      spreadsheetId: 'id',
+      range: 'A1',
+      top: { style: 'INVALID_STYLE' },
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds 7 new Google Sheets tools and extends the existing `formatCells` tool with two missing formatting options that were already supported by the underlying API helper but not exposed to MCP callers.

### New tools

| Tool | Description |
|---|---|
| `autoResizeRows` | Auto-resize row heights to fit content (mirrors existing `autoResizeColumns`) |
| `setRowHeights` | Set a fixed pixel height for a row range |
| `setCellBorders` | Set per-side borders (top/bottom/left/right/innerHorizontal/innerVertical) with style and color |
| `copySheetTo` | Copy a sheet tab to another spreadsheet (`spreadsheets.sheets.copyTo`) |
| `protectRange` | Lock a range or entire sheet — supports warning-only or fully locked mode |
| `getConditionalFormatting` | List all conditional formatting rules with their index (required for deletion) |
| `deleteConditionalFormatting` | Delete rules by index — auto-sorts descending to avoid index shifting |

### formatCells extended

- `verticalAlignment`: `TOP` / `MIDDLE` / `BOTTOM` — was already handled in `googleSheetsApiHelpers.ts` but missing from the Zod schema
- `wrapStrategy`: `OVERFLOW_CELL` / `CLIP` / `WRAP` — added to both the helper type and the tool schema

### googleSheetsApiHelpers.ts changes

- Added `wrapStrategy` to the `formatCells` format type
- Added `wrapStrategy` handling in `userEnteredFormat` and `fields` mask

### Validation highlights

- `autoResizeRows` and `setRowHeights`: `.refine()` to ensure `endRow >= startRow`
- `setCellBorders`: `.refine()` requiring at least one side specified
- `deleteConditionalFormatting`: auto-sorts indices descending before batch delete
- `getConditionalFormatting`: uses correct multi-letter column index conversion (handles columns beyond Z)

## Test plan

All tools were tested against a live Google Spreadsheet before submitting:

- [x] `autoResizeRows` — resized rows 6–10
- [x] `setRowHeights` — set rows 2–5 to 50px
- [x] `setCellBorders` — applied border to header row
- [x] `copySheetTo` — copied sheet to same file, verified title returned, deleted test copy
- [x] `protectRange` — protected header row (warning-only), Protection ID returned
- [x] `getConditionalFormatting` — listed 4 existing rules with correct ranges and colors
- [x] `deleteConditionalFormatting` — deleted rule 0, re-added via `addConditionalFormatting`
- [x] `formatCells` with `verticalAlignment: BOTTOM` — applied successfully
- [x] TypeScript build: `tsc` passes with no errors