### PR TITLE
feat: add Google Sheets comment tools (read, reply, resolve, delete)

### DIFF
--- a/src/tools/sheets/comments/deleteSheetsComment.ts
+++ b/src/tools/sheets/comments/deleteSheetsComment.ts
@@ -1,0 +1,36 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { getAuthClient } from '../../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'deleteSheetsComment',
+    description: 'Permanently deletes a comment and all its replies from a Google Spreadsheet.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+      commentId: z.string().describe('The ID of the comment to delete.'),
+    }),
+    execute: async (args, { log }) => {
+      log.info(`Deleting comment ${args.commentId} from spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const authClient = await getAuthClient();
+        const drive = google.drive({ version: 'v3', auth: authClient });
+
+        await drive.comments.delete({
+          fileId: args.spreadsheetId,
+          commentId: args.commentId,
+        });
+
+        return `Comment ${args.commentId} has been deleted.`;
+      } catch (error: any) {
+        log.error(`Error deleting sheets comment: ${error.message || error}`);
+        throw new UserError(`Failed to delete comment: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/comments/deleteSheetsComment.ts
+++ b/src/tools/sheets/comments/deleteSheetsComment.ts
@@ -11,7 +11,9 @@ export function register(server: FastMCP) {
     parameters: z.object({
       spreadsheetId: z
         .string()
-        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
       commentId: z.string().describe('The ID of the comment to delete.'),
     }),
     execute: async (args, { log }) => {

--- a/src/tools/sheets/comments/getSheetsComment.ts
+++ b/src/tools/sheets/comments/getSheetsComment.ts
@@ -12,7 +12,9 @@ export function register(server: FastMCP) {
     parameters: z.object({
       spreadsheetId: z
         .string()
-        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
       commentId: z.string().describe('The ID of the comment to retrieve.'),
     }),
     execute: async (args, { log }) => {
@@ -59,7 +61,9 @@ export function register(server: FastMCP) {
   });
 }
 
-function parseSheetsAnchor(anchorStr: string): { sheetId: number; row: number; col: number } | null {
+function parseSheetsAnchor(
+  anchorStr: string
+): { sheetId: number; row: number; col: number } | null {
   try {
     const anchor = JSON.parse(anchorStr);
     const actions = anchor.a;

--- a/src/tools/sheets/comments/getSheetsComment.ts
+++ b/src/tools/sheets/comments/getSheetsComment.ts
@@ -1,0 +1,90 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { getAuthClient } from '../../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'getSheetsComment',
+    description:
+      'Gets a specific comment and its full reply thread from a Google Spreadsheet. Use listSheetsComments first to find the comment ID.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+      commentId: z.string().describe('The ID of the comment to retrieve.'),
+    }),
+    execute: async (args, { log }) => {
+      log.info(`Getting comment ${args.commentId} from spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const authClient = await getAuthClient();
+        const drive = google.drive({ version: 'v3', auth: authClient });
+        const response = await drive.comments.get({
+          fileId: args.spreadsheetId,
+          commentId: args.commentId,
+          fields:
+            'id,content,anchor,quotedFileContent,author,createdTime,modifiedTime,resolved,replies(id,content,author,createdTime)',
+        });
+
+        const comment = response.data;
+        const cellInfo = comment.anchor ? parseSheetsAnchor(comment.anchor) : null;
+
+        return JSON.stringify(
+          {
+            id: comment.id,
+            author: comment.author?.displayName || null,
+            content: comment.content,
+            cell: cellInfo ? rowColToA1(cellInfo.row, cellInfo.col) : null,
+            quotedText: comment.quotedFileContent?.value || null,
+            resolved: comment.resolved || false,
+            createdTime: comment.createdTime,
+            modifiedTime: comment.modifiedTime,
+            replies: (comment.replies || []).map((r: any) => ({
+              id: r.id,
+              author: r.author?.displayName || null,
+              content: r.content,
+              createdTime: r.createdTime,
+            })),
+          },
+          null,
+          2
+        );
+      } catch (error: any) {
+        log.error(`Error getting sheets comment: ${error.message || error}`);
+        throw new UserError(`Failed to get comment: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}
+
+function parseSheetsAnchor(anchorStr: string): { sheetId: number; row: number; col: number } | null {
+  try {
+    const anchor = JSON.parse(anchorStr);
+    const actions = anchor.a;
+    if (!actions || !Array.isArray(actions)) return null;
+    for (const action of actions) {
+      if (action.sht) {
+        const sid = action.sht.sid;
+        const rng = action.sht.rng;
+        if (sid !== undefined && rng) {
+          return { sheetId: sid, row: rng.r || 0, col: rng.c || 0 };
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function rowColToA1(row: number, col: number): string {
+  let colStr = '';
+  let c = col;
+  do {
+    colStr = String.fromCharCode(65 + (c % 26)) + colStr;
+    c = Math.floor(c / 26) - 1;
+  } while (c >= 0);
+  return `${colStr}${row + 1}`;
+}

--- a/src/tools/sheets/comments/index.ts
+++ b/src/tools/sheets/comments/index.ts
@@ -1,0 +1,15 @@
+import type { FastMCP } from 'fastmcp';
+
+import { register as listSheetsComments } from './listSheetsComments.js';
+import { register as getSheetsComment } from './getSheetsComment.js';
+import { register as replyToSheetsComment } from './replyToSheetsComment.js';
+import { register as resolveSheetsComment } from './resolveSheetsComment.js';
+import { register as deleteSheetsComment } from './deleteSheetsComment.js';
+
+export function registerSheetsCommentTools(server: FastMCP) {
+  listSheetsComments(server);
+  getSheetsComment(server);
+  replyToSheetsComment(server);
+  resolveSheetsComment(server);
+  deleteSheetsComment(server);
+}

--- a/src/tools/sheets/comments/listSheetsComments.ts
+++ b/src/tools/sheets/comments/listSheetsComments.ts
@@ -1,0 +1,232 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { getAuthClient, getSheetsClient } from '../../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'listSheetsComments',
+    description:
+      'Lists all comments in a Google Spreadsheet. Filter by sheet name, specific row(s), specific cell, or a cell range. Returns comment IDs needed for getSheetsComment, replyToSheetsComment, resolveSheetsComment, or deleteSheetsComment.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+      sheetName: z
+        .string()
+        .optional()
+        .describe('Optional: filter comments to only this sheet/tab name.'),
+      row: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe('Optional: filter to comments on this specific row number (1-based, e.g., 5 for row 5).'),
+      rows: z
+        .array(z.number().int().min(1))
+        .optional()
+        .describe('Optional: filter to comments on any of these row numbers (1-based, e.g., [3, 5, 12]). Ignored if "row" is set.'),
+      cell: z
+        .string()
+        .optional()
+        .describe('Optional: filter to comments on this specific cell in A1 notation (e.g., "B3"). Overrides row/rows filters.'),
+      range: z
+        .string()
+        .optional()
+        .describe('Optional: filter to comments within this A1 range (e.g., "A1:D10", "B:B" for entire column B). Overrides row/rows/cell filters.'),
+      includeResolved: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe('If true, include resolved comments. Defaults to false.'),
+    }),
+    execute: async (args, { log }) => {
+      log.info(`Listing comments for spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const authClient = await getAuthClient();
+        const drive = google.drive({ version: 'v3', auth: authClient });
+
+        const comments: any[] = [];
+        let pageToken: string | undefined;
+
+        do {
+          const response = await drive.comments.list({
+            fileId: args.spreadsheetId,
+            fields: 'comments(id,content,anchor,quotedFileContent,author,createdTime,modifiedTime,resolved,replies(id,content,author,createdTime)),nextPageToken',
+            pageSize: 100,
+            ...(pageToken ? { pageToken } : {}),
+          });
+
+          comments.push(...(response.data.comments || []));
+          pageToken = response.data.nextPageToken || undefined;
+        } while (pageToken);
+
+        let sheetGidMap: Record<string, string> = {};
+        const needSheetMeta = args.sheetName || args.row || args.rows || args.cell || args.range;
+
+        if (needSheetMeta) {
+          const sheetsClient = await getSheetsClient();
+          const meta = await sheetsClient.spreadsheets.get({
+            spreadsheetId: args.spreadsheetId,
+            fields: 'sheets.properties',
+          });
+          for (const sheet of meta.data.sheets || []) {
+            const props = sheet.properties;
+            if (props?.sheetId !== undefined && props?.title) {
+              sheetGidMap[String(props.sheetId)] = props.title;
+            }
+          }
+        }
+
+        const rangeFilter = args.range ? parseA1Range(args.range) : null;
+        const cellFilter = args.cell ? a1ToRowCol(args.cell) : null;
+        const rowSet = args.row
+          ? new Set([args.row - 1])
+          : args.rows
+            ? new Set(args.rows.map((r) => r - 1))
+            : null;
+
+        const result = comments
+          .filter((c) => {
+            if (!args.includeResolved && c.resolved) return false;
+            const cellInfo = c.anchor ? parseSheetsAnchor(c.anchor) : null;
+
+            if (args.sheetName && cellInfo) {
+              const resolvedName = sheetGidMap[String(cellInfo.sheetId)];
+              if (resolvedName && resolvedName !== args.sheetName) return false;
+            }
+
+            if (!cellInfo) return !rangeFilter && !cellFilter && !rowSet;
+
+            if (rangeFilter) {
+              return cellInfo.row >= rangeFilter.startRow &&
+                cellInfo.row <= rangeFilter.endRow &&
+                cellInfo.col >= rangeFilter.startCol &&
+                cellInfo.col <= rangeFilter.endCol;
+            }
+            if (cellFilter) {
+              return cellInfo.row === cellFilter.row && cellInfo.col === cellFilter.col;
+            }
+            if (rowSet) {
+              return rowSet.has(cellInfo.row);
+            }
+            return true;
+          })
+          .map((comment: any) => {
+            const cellInfo = comment.anchor ? parseSheetsAnchor(comment.anchor) : null;
+            let cellRef: string | null = null;
+            let sheetTitle: string | null = null;
+
+            if (cellInfo) {
+              cellRef = rowColToA1(cellInfo.row, cellInfo.col);
+              if (Object.keys(sheetGidMap).length > 0) {
+                sheetTitle = sheetGidMap[String(cellInfo.sheetId)] || null;
+              }
+            }
+
+            return {
+              id: comment.id,
+              author: comment.author?.displayName || null,
+              content: comment.content,
+              cell: cellRef,
+              sheetName: sheetTitle,
+              quotedText: comment.quotedFileContent?.value || null,
+              resolved: comment.resolved || false,
+              createdTime: comment.createdTime,
+              modifiedTime: comment.modifiedTime,
+              replyCount: comment.replies?.length || 0,
+            };
+          });
+
+        return JSON.stringify({ comments: result, total: result.length }, null, 2);
+      } catch (error: any) {
+        log.error(`Error listing sheets comments: ${error.message || error}`);
+        throw new UserError(`Failed to list spreadsheet comments: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}
+
+function parseSheetsAnchor(anchorStr: string): { sheetId: number; row: number; col: number } | null {
+  try {
+    const anchor = JSON.parse(anchorStr);
+    const actions = anchor.a;
+    if (!actions || !Array.isArray(actions)) return null;
+    for (const action of actions) {
+      if (action.sht) {
+        const sid = action.sht.sid;
+        const rng = action.sht.rng;
+        if (sid !== undefined && rng) {
+          return { sheetId: sid, row: rng.r || 0, col: rng.c || 0 };
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function rowColToA1(row: number, col: number): string {
+  let colStr = '';
+  let c = col;
+  do {
+    colStr = String.fromCharCode(65 + (c % 26)) + colStr;
+    c = Math.floor(c / 26) - 1;
+  } while (c >= 0);
+  return `${colStr}${row + 1}`;
+}
+
+function a1ToRowCol(a1: string): { row: number; col: number } {
+  const match = a1.match(/^([A-Za-z]+)(\d+)$/);
+  if (!match) return { row: 0, col: 0 };
+  const colStr = match[1].toUpperCase();
+  let col = 0;
+  for (let i = 0; i < colStr.length; i++) {
+    col = col * 26 + (colStr.charCodeAt(i) - 64);
+  }
+  return { row: parseInt(match[2], 10) - 1, col: col - 1 };
+}
+
+function parseA1Range(range: string): { startRow: number; endRow: number; startCol: number; endCol: number } {
+  const stripped = range.includes('!') ? range.split('!')[1] : range;
+  const parts = stripped.split(':');
+
+  const colOnly = /^[A-Za-z]+$/;
+  const rowOnly = /^\d+$/;
+
+  const parseCorner = (s: string): { row: number | null; col: number | null } => {
+    if (colOnly.test(s)) {
+      const upper = s.toUpperCase();
+      let c = 0;
+      for (let i = 0; i < upper.length; i++) c = c * 26 + (upper.charCodeAt(i) - 64);
+      return { row: null, col: c - 1 };
+    }
+    if (rowOnly.test(s)) {
+      return { row: parseInt(s, 10) - 1, col: null };
+    }
+    const rc = a1ToRowCol(s);
+    return { row: rc.row, col: rc.col };
+  };
+
+  if (parts.length === 1) {
+    const p = parseCorner(parts[0]);
+    return {
+      startRow: p.row ?? 0,
+      endRow: p.row ?? 999999,
+      startCol: p.col ?? 0,
+      endCol: p.col ?? 999999,
+    };
+  }
+
+  const start = parseCorner(parts[0]);
+  const end = parseCorner(parts[1]);
+  return {
+    startRow: start.row ?? 0,
+    endRow: end.row ?? 999999,
+    startCol: start.col ?? 0,
+    endCol: end.col ?? 999999,
+  };
+}

--- a/src/tools/sheets/comments/listSheetsComments.ts
+++ b/src/tools/sheets/comments/listSheetsComments.ts
@@ -12,7 +12,9 @@ export function register(server: FastMCP) {
     parameters: z.object({
       spreadsheetId: z
         .string()
-        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
       sheetName: z
         .string()
         .optional()
@@ -22,19 +24,27 @@ export function register(server: FastMCP) {
         .int()
         .min(1)
         .optional()
-        .describe('Optional: filter to comments on this specific row number (1-based, e.g., 5 for row 5).'),
+        .describe(
+          'Optional: filter to comments on this specific row number (1-based, e.g., 5 for row 5).'
+        ),
       rows: z
         .array(z.number().int().min(1))
         .optional()
-        .describe('Optional: filter to comments on any of these row numbers (1-based, e.g., [3, 5, 12]). Ignored if "row" is set.'),
+        .describe(
+          'Optional: filter to comments on any of these row numbers (1-based, e.g., [3, 5, 12]). Ignored if "row" is set.'
+        ),
       cell: z
         .string()
         .optional()
-        .describe('Optional: filter to comments on this specific cell in A1 notation (e.g., "B3"). Overrides row/rows filters.'),
+        .describe(
+          'Optional: filter to comments on this specific cell in A1 notation (e.g., "B3"). Overrides row/rows filters.'
+        ),
       range: z
         .string()
         .optional()
-        .describe('Optional: filter to comments within this A1 range (e.g., "A1:D10", "B:B" for entire column B). Overrides row/rows/cell filters.'),
+        .describe(
+          'Optional: filter to comments within this A1 range (e.g., "A1:D10", "B:B" for entire column B). Overrides row/rows/cell filters.'
+        ),
       includeResolved: z
         .boolean()
         .optional()
@@ -54,7 +64,8 @@ export function register(server: FastMCP) {
         do {
           const response = await drive.comments.list({
             fileId: args.spreadsheetId,
-            fields: 'comments(id,content,anchor,quotedFileContent,author,createdTime,modifiedTime,resolved,replies(id,content,author,createdTime)),nextPageToken',
+            fields:
+              'comments(id,content,anchor,quotedFileContent,author,createdTime,modifiedTime,resolved,replies(id,content,author,createdTime)),nextPageToken',
             pageSize: 100,
             ...(pageToken ? { pageToken } : {}),
           });
@@ -101,10 +112,12 @@ export function register(server: FastMCP) {
             if (!cellInfo) return !rangeFilter && !cellFilter && !rowSet;
 
             if (rangeFilter) {
-              return cellInfo.row >= rangeFilter.startRow &&
+              return (
+                cellInfo.row >= rangeFilter.startRow &&
                 cellInfo.row <= rangeFilter.endRow &&
                 cellInfo.col >= rangeFilter.startCol &&
-                cellInfo.col <= rangeFilter.endCol;
+                cellInfo.col <= rangeFilter.endCol
+              );
             }
             if (cellFilter) {
               return cellInfo.row === cellFilter.row && cellInfo.col === cellFilter.col;
@@ -143,13 +156,17 @@ export function register(server: FastMCP) {
         return JSON.stringify({ comments: result, total: result.length }, null, 2);
       } catch (error: any) {
         log.error(`Error listing sheets comments: ${error.message || error}`);
-        throw new UserError(`Failed to list spreadsheet comments: ${error.message || 'Unknown error'}`);
+        throw new UserError(
+          `Failed to list spreadsheet comments: ${error.message || 'Unknown error'}`
+        );
       }
     },
   });
 }
 
-function parseSheetsAnchor(anchorStr: string): { sheetId: number; row: number; col: number } | null {
+function parseSheetsAnchor(
+  anchorStr: string
+): { sheetId: number; row: number; col: number } | null {
   try {
     const anchor = JSON.parse(anchorStr);
     const actions = anchor.a;
@@ -190,7 +207,12 @@ function a1ToRowCol(a1: string): { row: number; col: number } {
   return { row: parseInt(match[2], 10) - 1, col: col - 1 };
 }
 
-function parseA1Range(range: string): { startRow: number; endRow: number; startCol: number; endCol: number } {
+function parseA1Range(range: string): {
+  startRow: number;
+  endRow: number;
+  startCol: number;
+  endCol: number;
+} {
   const stripped = range.includes('!') ? range.split('!')[1] : range;
   const parts = stripped.split(':');
 

--- a/src/tools/sheets/comments/replyToSheetsComment.ts
+++ b/src/tools/sheets/comments/replyToSheetsComment.ts
@@ -12,7 +12,9 @@ export function register(server: FastMCP) {
     parameters: z.object({
       spreadsheetId: z
         .string()
-        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
       commentId: z.string().describe('The ID of the comment to reply to.'),
       content: z.string().min(1).describe('The text content of the reply.'),
     }),

--- a/src/tools/sheets/comments/replyToSheetsComment.ts
+++ b/src/tools/sheets/comments/replyToSheetsComment.ts
@@ -1,0 +1,42 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { getAuthClient } from '../../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'replyToSheetsComment',
+    description:
+      'Adds a reply to an existing comment thread in a Google Spreadsheet. Use listSheetsComments or getSheetsComment to find the comment ID.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+      commentId: z.string().describe('The ID of the comment to reply to.'),
+      content: z.string().min(1).describe('The text content of the reply.'),
+    }),
+    execute: async (args, { log }) => {
+      log.info(`Adding reply to comment ${args.commentId} in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const authClient = await getAuthClient();
+        const drive = google.drive({ version: 'v3', auth: authClient });
+
+        const response = await drive.replies.create({
+          fileId: args.spreadsheetId,
+          commentId: args.commentId,
+          fields: 'id,content,author,createdTime',
+          requestBody: {
+            content: args.content,
+          },
+        });
+
+        return `Reply added successfully. Reply ID: ${response.data.id}`;
+      } catch (error: any) {
+        log.error(`Error adding reply to sheets comment: ${error.message || error}`);
+        throw new UserError(`Failed to add reply: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/comments/resolveSheetsComment.ts
+++ b/src/tools/sheets/comments/resolveSheetsComment.ts
@@ -1,0 +1,60 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { getAuthClient } from '../../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'resolveSheetsComment',
+    description:
+      'Marks a comment as resolved in a Google Spreadsheet. Note: resolved status may not persist in the Sheets UI due to a Drive API limitation.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+      commentId: z.string().describe('The ID of the comment to resolve.'),
+    }),
+    execute: async (args, { log }) => {
+      log.info(`Resolving comment ${args.commentId} in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const authClient = await getAuthClient();
+        const drive = google.drive({ version: 'v3', auth: authClient });
+
+        const currentComment = await drive.comments.get({
+          fileId: args.spreadsheetId,
+          commentId: args.commentId,
+          fields: 'content',
+        });
+
+        await drive.comments.update({
+          fileId: args.spreadsheetId,
+          commentId: args.commentId,
+          fields: 'id,resolved',
+          requestBody: {
+            content: currentComment.data.content,
+            resolved: true,
+          },
+        });
+
+        const verifyComment = await drive.comments.get({
+          fileId: args.spreadsheetId,
+          commentId: args.commentId,
+          fields: 'resolved',
+        });
+
+        if (verifyComment.data.resolved) {
+          return `Comment ${args.commentId} has been marked as resolved.`;
+        } else {
+          return `Attempted to resolve comment ${args.commentId}, but the resolved status may not persist in the Sheets UI due to API limitations. The comment can be resolved manually in the Google Sheets interface.`;
+        }
+      } catch (error: any) {
+        log.error(`Error resolving sheets comment: ${error.message || error}`);
+        const errorDetails =
+          error.response?.data?.error?.message || error.message || 'Unknown error';
+        throw new UserError(`Failed to resolve comment: ${errorDetails}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/comments/resolveSheetsComment.ts
+++ b/src/tools/sheets/comments/resolveSheetsComment.ts
@@ -12,7 +12,9 @@ export function register(server: FastMCP) {
     parameters: z.object({
       spreadsheetId: z
         .string()
-        .describe('The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'),
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
       commentId: z.string().describe('The ID of the comment to resolve.'),
     }),
     execute: async (args, { log }) => {

--- a/src/tools/sheets/index.ts
+++ b/src/tools/sheets/index.ts
@@ -31,6 +31,9 @@ import { register as addConditionalFormatting } from './addConditionalFormatting
 import { register as groupRows } from './groupRows.js';
 import { register as ungroupAllRows } from './ungroupAllRows.js';
 
+// Comments
+import { registerSheetsCommentTools } from './comments/index.js';
+
 // Tables
 import { register as createTable } from './createTable.js';
 import { register as listTables } from './listTables.js';
@@ -73,6 +76,9 @@ export function registerSheetsTools(server: FastMCP) {
   addConditionalFormatting(server);
   groupRows(server);
   ungroupAllRows(server);
+
+  // Comments
+  registerSheetsCommentTools(server);
 
   // Tables
   createTable(server);


### PR DESCRIPTION
Adds 5 new tools for interacting with comments on Google Spreadsheets via the Drive API v3:

- listSheetsComments: list comments with filtering by sheet, row(s), cell, or A1 range
- getSheetsComment: get a comment with its full reply thread
- replyToSheetsComment: reply to an existing comment thread
- resolveSheetsComment: mark a comment as resolved
- deleteSheetsComment: delete a comment

Note: creating new cell-anchored comments is not supported due to a known Google API limitation (Drive API comments on Sheets do not anchor to cells). These tools focus on reading and responding to comments created through the Sheets UI.