### PR TITLE
feat: add planning-doc formatting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,23 @@ The server supports a full round-trip markdown workflow:
 
 Supported: headings, bold, italic, strikethrough, links, bullet/numbered lists, horizontal rules.
 
+### Live Docs Verification
+
+The repository includes an opt-in live integration test for `cloneTable` against the real Google Docs API. It is skipped by default.
+
+Requirements:
+
+- valid `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+- an authorized token already stored via `npx -y @a-bonus/google-docs-mcp auth`
+
+Run it with:
+
+```bash
+GOOGLE_DOCS_LIVE_TESTS=1 npm run test:live:docs
+```
+
+This test creates temporary source/target Google Docs, verifies `cloneTable`, and then deletes the test files.
+
 ---
 
 ## Remote Deployment

--- a/docs/planning-doc-formatting-implementation-plan.md
+++ b/docs/planning-doc-formatting-implementation-plan.md
@@ -1,0 +1,336 @@
+# Implementation Plan: Planning Doc Formatting Support
+
+**Scope**: `google-docs-mcp`  
+**Related Spec**: [planning-doc-formatting-spec.md](./planning-doc-formatting-spec.md)  
+**Last Updated**: 2026-04-27
+
+## 1. Objective
+
+Implement the minimum set of Google Docs MCP capabilities needed to update rich planning documents without destroying their formatting.
+
+This plan is intentionally tied to the current codebase structure so implementation can proceed incrementally.
+
+## 2. Current Codebase Mapping
+
+Relevant existing files:
+
+- `src/tools/docs/index.ts`
+  - Docs tool router
+- `src/tools/docs/readGoogleDoc.ts`
+  - document fetch and content conversion
+- `src/tools/docs/insertTableWithData.ts`
+  - current table insertion logic
+- `src/tools/docs/formatting/applyTextStyle.ts`
+  - text-level style application
+- `src/googleDocsApiHelpers.ts`
+  - shared request builders, tab helpers, search helpers, batch update utilities
+- `src/types.ts`
+  - shared zod schemas and tool argument types
+
+Current limitation:
+
+- table operations are insertion-oriented, not template-preserving
+- formatting support is text-first, not table-first
+- no stable table discovery API exists
+- smart chip support is incomplete and not yet verified end-to-end
+
+## 3. Delivery Strategy
+
+The work should be delivered in 5 phases.
+
+## 4. Phase 1: Discovery and Safe Targeting
+
+### Goal
+
+Allow an agent to locate the correct table and heading section before mutating anything.
+
+### Deliverables
+
+- `listDocumentTables`
+- `getTableStructure`
+- `findSectionsByHeading`
+- helper extraction layer for document tables and headings
+
+### Code Locations
+
+- `src/tools/docs/listDocumentTables.ts`
+- `src/tools/docs/getTableStructure.ts`
+- `src/tools/docs/findSectionsByHeading.ts`
+- `src/tools/docs/structureHelpers.ts`
+- `src/tools/docs/index.ts`
+
+### Notes
+
+- Table IDs should remain MCP-generated and stable within a single read pass.
+- For now, IDs can be ordinal-based: `table:<tab-or-body>:<ordinal>`.
+- This phase should avoid introducing any write-side table mutation yet.
+
+### Validation
+
+- unit tests for table extraction and heading lookup
+- manual invocation on a real planning doc
+
+## 5. Phase 2: Plain Row Replacement Without Format Loss
+
+### Goal
+
+Allow replacing, appending, and deleting table rows while preserving existing table formatting.
+
+### Deliverables
+
+- `appendTableRows`
+- `deleteTableRows`
+- `replaceTableRowData`
+
+### Technical Direction
+
+Preferred implementation:
+
+1. read full document structure
+2. locate target table and target row cells
+3. mutate cell contents through targeted delete/insert requests
+4. preserve table structure itself
+
+### Design Constraint
+
+Do not use `replaceDocumentWithMarkdown` for planning doc tables once these tools exist.
+
+### Code Locations
+
+- `src/tools/docs/appendTableRows.ts`
+- `src/tools/docs/deleteTableRows.ts`
+- `src/tools/docs/replaceTableRowData.ts`
+- `src/googleDocsApiHelpers.ts`
+
+### Risks
+
+- Google Docs table indexes shift as text is inserted/deleted
+- row insertion may require careful reverse-order updates
+- merged cells are out of scope for the first implementation
+
+## 6. Phase 3: Table Presentation Controls
+
+### Goal
+
+Enable recreation of the visual structure expected in planning docs.
+
+### Deliverables
+
+- `updateTableCellStyle`
+- `updateTableBorders`
+- `updateTableColumnWidth`
+- `updateTableRowStyle`
+
+### Technical Direction
+
+Add request builders in `googleDocsApiHelpers.ts` for:
+
+- cell background
+- cell alignment
+- border style
+- row height
+- column width
+
+### Code Locations
+
+- `src/tools/docs/updateTableCellStyle.ts`
+- `src/tools/docs/updateTableBorders.ts`
+- `src/tools/docs/updateTableColumnWidth.ts`
+- `src/tools/docs/updateTableRowStyle.ts`
+- `src/types.ts`
+- `src/googleDocsApiHelpers.ts`
+
+### Acceptance Criteria
+
+- header row can be shaded blue
+- `No.` column can be narrow
+- `メモ / 相談` column can be wide
+- borders remain clean and consistent
+
+## 7. Phase 4: Rich Content Inside Table Cells
+
+### Goal
+
+Render memo cells as readable structured content rather than flat strings.
+
+### Deliverables
+
+- `RichCellContent` model
+- support for multiple paragraphs inside a cell
+- support for bullet lists inside a cell
+- support for mixed bold/plain/link text runs inside a cell
+
+### Technical Direction
+
+Introduce a structured input model instead of overloading Markdown tables.
+
+Suggested model:
+
+- paragraph blocks
+- bulleted list blocks
+- numbered list blocks
+- styled text runs inside each block
+
+### Code Locations
+
+- `src/types.ts`
+- `src/googleDocsApiHelpers.ts`
+- row mutation tools from phase 2
+
+### Acceptance Criteria
+
+Memo cells can represent:
+
+- `影響箇所`
+- bullet list
+- `対応方針`
+- bullet list
+- `想定成果物`
+- bullet list
+
+without corrupting the table layout.
+
+## 8. Phase 5: Smart Chips and Template-Aware Updates
+
+### Goal
+
+Support planning-doc metadata and template reuse.
+
+### Deliverables
+
+- `insertDateChip`
+- `insertPerson`
+- `insertRichLink`
+- `listSmartChips`
+- `cloneTable`
+- optional higher-level planning-template updater
+
+### Technical Direction
+
+Smart chips:
+
+- investigate exact Docs API support available through current `googleapis` version
+- if chip insertion is partially unsupported, provide a clear fallback mode
+
+Template reuse:
+
+- clone a formatted table from an old planning document
+- only replace sprint rows
+
+### Code Locations
+
+- `src/tools/docs/insertDateChip.ts`
+- `src/tools/docs/insertPerson.ts`
+- `src/tools/docs/insertRichLink.ts`
+- `src/tools/docs/listSmartChips.ts`
+- `src/tools/docs/cloneTable.ts`
+- helper additions in `src/googleDocsApiHelpers.ts`
+
+## 9. Delivery Status
+
+Status as of 2026-04-27:
+
+- Phase 1: implemented at tool surface level with helper tests
+- Phase 2: implemented at tool surface level with row mutation helpers and tests
+- Phase 3: implemented at tool surface level with request-builder tests
+- Phase 5 smart-chip subset: started early
+- Phase 5 template subset: started with `cloneTable`
+
+Early smart-chip work currently includes:
+
+- `insertDateChip`
+- `insertPerson`
+- `insertRichLink`
+- `listSmartChips`
+- `smartChipHelpers`
+
+This was pulled ahead of the original order because planning-doc metadata support is a blocker for realistic template updates.
+
+Early template work currently includes:
+
+- `cloneTable`
+- `extractTableSnapshot`
+- nearest-target-table re-identification after insert
+
+## 10. Suggested Implementation Order
+
+Recommended execution order for actual coding:
+
+1. phase 1 discovery tools
+2. plain row append/delete/replace
+3. header row styling and column sizing
+4. rich memo cell content
+5. date/person/rich-link chip insertion
+6. template cloning
+
+This order keeps the system useful after each increment.
+
+## 11. Test Plan
+
+### Unit Tests
+
+Add tests for:
+
+- extracting tables from document JSON
+- finding headings and associated tables
+- resolving row/cell addressing
+- building table style requests
+- building row replacement requests
+
+### Integration Tests
+
+Add live or mocked integration coverage for:
+
+- list tables on a document with a single planning table
+- replace only table body rows
+- preserve table header row
+- insert a date chip
+
+### Manual Tests
+
+Use a real planning document to verify:
+
+1. task table is found correctly
+2. rows can be updated without replacing the whole doc
+3. old formatting remains intact
+4. datetime line remains interactive once chips are supported
+
+## 11. Status
+
+Implemented in this iteration:
+
+- `listDocumentTables`
+- `getTableStructure`
+- `findSectionsByHeading`
+- `structureHelpers` test coverage
+- `replaceTableRowData`
+- `appendTableRows`
+- `deleteTableRows`
+- shared row-content replacement helpers
+- shared table row request builders
+- `updateTableCellStyle`
+- `updateTableBorders`
+- `updateTableColumnWidth`
+- `updateTableRowStyle`
+- shared table formatting request builders
+- unit tests for table formatting request builders
+
+Not yet implemented:
+
+- verified end-to-end row mutation against a live document
+- verified end-to-end table styling against a live document
+- smart chip tools
+- template cloning
+- rich memo cell content blocks
+
+## 12. Immediate Next Task
+
+The next implementation task should be:
+
+### Smart chip tools + template cloning
+
+Reason:
+
+- row mutation and basic styling tool surfaces now exist
+- the next blockers for planning docs are clickable metadata chips and template-preserving cloning
+- without those, planning docs can improve visually but still cannot fully match the existing manual workflow

--- a/docs/planning-doc-formatting-spec.md
+++ b/docs/planning-doc-formatting-spec.md
@@ -1,0 +1,678 @@
+# Google Docs MCP Spec: Rich Planning Document Formatting
+
+**Status**: Draft  
+**Owner**: TBD  
+**Last Updated**: 2026-04-27  
+**Target Repo**: `google-docs-mcp`
+
+## 1. Problem
+
+The current Google Docs MCP server can update document text, apply character-level text styles, and insert tables. That is enough for plain document editing, but it is not enough for structured planning documents that rely on rich Google Docs formatting.
+
+The concrete failure mode is planning documents like:
+
+- clickable date/time chips at the top of the document
+- visually distinct title chips or chip-like metadata blocks
+- tables with colored header rows
+- controlled column widths and row heights
+- structured multi-line content inside a single table cell
+- copying an existing table template and replacing only the task data
+- patching content while preserving document-specific rich formatting
+
+Today, when the MCP server replaces content via Markdown:
+
+- smart chips degrade into plain text
+- table header background colors are lost
+- cell spacing and layout are lost
+- multi-line memo content becomes ugly or breaks table structure
+- links may be reintroduced, but the final result is still far from the expected visual output
+
+## 2. Goal
+
+Enable `google-docs-mcp` to create and update planning documents so they remain visually close to manually curated Google Docs templates.
+
+The server should support a workflow where an agent can:
+
+1. locate a preformatted planning template or an existing planning document
+2. identify rich blocks such as title area and task tables
+3. replace only the sprint-specific data
+4. preserve styling, spacing, smart chips, and table layout
+5. verify that the output is structurally correct
+
+## 3. Non-Goals
+
+- Full WYSIWYG layout editing for every Google Docs feature
+- Pixel-perfect browser automation as the primary implementation path
+- Solving arbitrary desktop publishing use cases
+- Replicating all Google Docs UI interactions in MCP
+
+This spec focuses on the minimum rich formatting capabilities needed for planning documents.
+
+## 4. Primary Use Case
+
+### 4.1 Input
+
+A user provides:
+
+- a target planning document
+- a source sprint or milestone task list
+- optionally an old planning document that already has the desired format
+
+### 4.2 Expected Output
+
+The target document should have:
+
+- top metadata line rendered as a clickable date chip where appropriate
+- preserved title appearance
+- preserved heading structure
+- preserved task tables with header shading and borders
+- preserved table layout
+- sprint task rows updated with new content
+- memo cells containing readable sub-sections such as:
+  - `影響箇所`
+  - `対応方針`
+  - `想定成果物`
+
+## 5. Current Capability Gap
+
+Current repo capabilities:
+
+- `readDocument`
+- `replaceDocumentWithMarkdown`
+- `replaceRangeWithMarkdown`
+- `applyTextStyle`
+- `insertTableWithData`
+- document text insertion/deletion helpers
+
+Missing capabilities:
+
+- smart chip creation and reading
+- table-level cell styling
+- table border styling
+- column width and row height control
+- structured rich text inside a table cell
+- template table cloning
+- row-level data replacement without losing formatting
+- discovery APIs for finding tables and sections
+- verification APIs for structural validation
+
+## 6. Product Requirements
+
+### 6.1 Smart Chips
+
+The MCP server must support reading and inserting smart chips for planning doc metadata.
+
+Required chip types:
+
+- date chip
+- person chip
+- file chip
+- rich link chip
+
+Minimum required for this planning-doc feature:
+
+- date chip
+
+### 6.2 Table Formatting
+
+The MCP server must support formatting Google Docs tables at cell, row, column, and table range levels.
+
+Required formatting controls:
+
+- background color
+- text alignment
+- vertical alignment
+- padding
+- row minimum height
+- column width
+- border style
+- border width
+- border color
+
+### 6.3 Structured Cell Content
+
+The MCP server must support rendering multi-line rich content inside a single table cell without breaking the table.
+
+Required content patterns:
+
+- bold labels followed by body text
+- bullet list sections
+- multiple paragraphs in one cell
+- links inside cell content
+
+### 6.4 Template-Preserving Updates
+
+The MCP server must support copying an existing formatted table or updating rows inside that table without destroying the format.
+
+Required behaviors:
+
+- clone a table from an existing doc or from another location in the same doc
+- replace row contents only
+- append and delete rows while preserving styling
+- preserve header row styling
+
+### 6.5 Section-Level Patching
+
+The MCP server must support replacing content inside a named section without touching unrelated rich formatting elsewhere in the document.
+
+Required section anchors:
+
+- heading-based selection
+- table-based selection
+- range-based fallback
+
+### 6.6 Verification
+
+The MCP server must support structural verification so an agent can confirm whether the document matches the intended output.
+
+Required checks:
+
+- section exists
+- table exists with expected dimensions
+- header row style present
+- link fields present where expected
+- smart chip exists where expected
+
+## 7. Proposed MCP Tool Additions
+
+This section defines proposed tools or helper-level capabilities. Final naming can change, but the functional coverage should remain.
+
+### 7.1 Smart Chip Tools
+
+#### `insertDateChip`
+
+Insert a date chip at a document position.
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  index: number;
+  date: string; // ISO-like date or date-time
+  timezone?: string;
+  displayFormat?: "DATE" | "DATE_TIME";
+}
+```
+
+#### `listSmartChips`
+
+Read smart chips from a document or range.
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  startIndex?: number;
+  endIndex?: number;
+}
+```
+
+Response should include:
+
+- chip type
+- display text
+- range
+- backing metadata
+
+### 7.2 Table Discovery Tools
+
+#### `listDocumentTables`
+
+Return all tables in a document with identifiers and structure.
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+}
+```
+
+Response should include:
+
+- `tableId`
+- `startIndex`
+- `endIndex`
+- `rowCount`
+- `columnCount`
+- optional header-row detection
+
+#### `getTableStructure`
+
+Return detailed cell map for a single table.
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+}
+```
+
+### 7.3 Table Styling Tools
+
+#### `updateTableCellStyle`
+
+Apply style to one or more cells.
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+  range: {
+    rowStart: number;
+    rowEnd: number;
+    columnStart: number;
+    columnEnd: number;
+  };
+  style: {
+    backgroundColor?: string;
+    contentAlignment?: "START" | "CENTER" | "END";
+    verticalAlignment?: "TOP" | "MIDDLE" | "BOTTOM";
+    paddingTopPt?: number;
+    paddingBottomPt?: number;
+    paddingLeftPt?: number;
+    paddingRightPt?: number;
+  };
+}
+```
+
+#### `updateTableBorders`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+  range?: {
+    rowStart: number;
+    rowEnd: number;
+    columnStart: number;
+    columnEnd: number;
+  };
+  borders: {
+    top?: BorderStyle;
+    right?: BorderStyle;
+    bottom?: BorderStyle;
+    left?: BorderStyle;
+    innerHorizontal?: BorderStyle;
+    innerVertical?: BorderStyle;
+  };
+}
+
+type BorderStyle = {
+  color?: string;
+  widthPt?: number;
+  dashStyle?: "SOLID" | "DOTTED" | "DASHED";
+};
+```
+
+#### `updateTableColumnWidth`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+  columnIndex: number;
+  widthPt: number;
+}
+```
+
+#### `updateTableRowStyle`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+  rowIndex: number;
+  minHeightPt?: number;
+  repeatAsHeaderRow?: boolean;
+}
+```
+
+### 7.4 Template / Clone Tools
+
+#### `cloneTable`
+
+Clone an existing table within the same document or from another document.
+
+```ts
+{
+  sourceDocumentId: string;
+  sourceTabId?: string;
+  sourceTableId: string;
+  targetDocumentId: string;
+  targetTabId?: string;
+  insertIndex: number;
+}
+```
+
+This is the most important capability for planning-doc preservation.
+
+### 7.5 Row Data Operations
+
+#### `replaceTableRowData`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+  rowIndex: number;
+  values: Array<RichCellContent>;
+}
+```
+
+#### `appendTableRows`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+  rows: Array<Array<RichCellContent>>;
+  copyStyleFromRowIndex?: number;
+}
+```
+
+#### `deleteTableRows`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  tableId: string;
+  rowStart: number;
+  rowCount: number;
+}
+```
+
+### 7.6 Rich Cell Content
+
+#### `RichCellContent`
+
+The current Markdown table approach is too weak for planning-doc cells. We need a structured content model.
+
+```ts
+type RichCellContent = {
+  blocks: Array<
+    | {
+        type: 'paragraph';
+        runs: TextRun[];
+      }
+    | {
+        type: 'bulletedList';
+        items: Array<{ runs: TextRun[] }>;
+      }
+    | {
+        type: 'numberedList';
+        items: Array<{ runs: TextRun[] }>;
+      }
+  >;
+};
+
+type TextRun = {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  foregroundColor?: string;
+  linkUrl?: string;
+};
+```
+
+This model is enough to represent:
+
+- `影響箇所` as bold paragraph
+- a bullet list of impacted screens
+- `対応方針` as bold paragraph
+- a bullet list of implementation steps
+- `想定成果物` as bold paragraph
+- a bullet list of PR / tests / evidence
+
+### 7.7 Section Discovery and Patching
+
+#### `findSectionsByHeading`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  headings: string[];
+}
+```
+
+#### `replaceSectionContent`
+
+```ts
+{
+  documentId: string;
+  tabId?: string;
+  sectionHeading: string;
+  content: SectionContent;
+  preserveSectionHeading?: boolean;
+}
+```
+
+This avoids replacing the full document when only the sprint table needs changing.
+
+## 8. Internal Helper Additions
+
+The repo likely also needs helper-level building blocks, not only public tools.
+
+Suggested internal helpers:
+
+- `extractTablesFromDocumentJson`
+- `buildInsertDateChipRequest`
+- `buildUpdateTableCellStyleRequests`
+- `buildUpdateTableBorderRequests`
+- `buildUpdateColumnWidthRequests`
+- `buildReplaceTableRowRequests`
+- `buildCloneTableRequests`
+- `buildRichCellContentRequests`
+- `findHeadingRange`
+- `findTableFollowingHeading`
+
+## 9. Suggested Implementation Strategy
+
+### Phase 1: Discovery and Non-Destructive Editing
+
+Implement:
+
+- `listDocumentTables`
+- `getTableStructure`
+- `findSectionsByHeading`
+- `replaceTableRowData` for plain text cells
+
+Outcome:
+
+- can target the right table
+- can replace rows without replacing the entire document
+
+### Phase 2: Table Presentation Controls
+
+Implement:
+
+- `updateTableCellStyle`
+- `updateTableBorders`
+- `updateTableColumnWidth`
+- `updateTableRowStyle`
+
+Outcome:
+
+- can reconstruct clean planning tables
+- can restore header shading and widths
+
+### Phase 3: Rich Cell Content
+
+Implement:
+
+- `RichCellContent`
+- paragraph/list rendering inside cells
+- row append/delete with style preservation
+
+Outcome:
+
+- can render `メモ / 相談` cleanly
+
+### Phase 4: Smart Chips
+
+Implement:
+
+- `insertDateChip`
+- `listSmartChips`
+
+Outcome:
+
+- can produce clickable planning metadata line
+
+### Phase 5: Template Cloning
+
+Implement:
+
+- `cloneTable`
+- style-copy helpers
+
+Outcome:
+
+- can take an old planning doc as template and only replace sprint data
+
+## 10. API Design Notes
+
+### 10.1 Favor Structure over Markdown for Tables
+
+Markdown is still good for headings and simple text, but it is not sufficient for rich Google Docs tables.
+
+Recommendation:
+
+- keep Markdown tools for simple document edits
+- introduce structured table-editing tools for rich docs
+
+### 10.2 Preserve Existing Tools
+
+Do not break:
+
+- `replaceDocumentWithMarkdown`
+- `readDocument`
+- `applyTextStyle`
+- `insertTableWithData`
+
+Add new tools beside them.
+
+### 10.3 Stable Table Identifiers
+
+Since Google Docs does not expose user-friendly table IDs directly, the MCP layer should generate stable table identifiers from:
+
+- table start index
+- ordinal position in tab
+- optional nearby heading anchor
+
+Example:
+
+- `table:t.0:3`
+- `table:t.0:heading-今回のスプリントのタスク:0`
+
+## 11. Validation and Testing
+
+### 11.1 Unit Tests
+
+Add tests for:
+
+- document JSON table extraction
+- smart chip request builders
+- cell-style request builders
+- border request builders
+- row replacement builders
+- rich cell content builders
+
+### 11.2 Integration Tests
+
+Add integration tests for:
+
+1. cloning a table from a template doc
+2. replacing task rows only
+3. preserving header styles
+4. rendering memo content with paragraphs and bullets
+5. inserting a date chip
+
+### 11.3 Golden Tests
+
+Use golden JSON snapshots or exported markdown/json shape comparisons for:
+
+- source template doc structure
+- updated target doc structure
+
+### 11.4 Manual Acceptance Tests
+
+Acceptance criteria for the planning-doc scenario:
+
+1. The metadata line shows a clickable date chip or equivalent chip object.
+2. The task table header row remains shaded.
+3. Column widths remain visually appropriate.
+4. Task rows are updated without corrupting the rest of the document.
+5. Memo cells remain readable and structured.
+6. A second update run is idempotent and does not duplicate rows.
+
+## 12. Backward Compatibility
+
+The new tools should be additive.
+
+Existing clients should continue working without any changes.
+
+If any helper refactor is needed, keep the public tool behavior unchanged for:
+
+- Markdown-based full document replacement
+- plain-text reading
+- simple text styling
+
+## 13. Example End-to-End Agent Workflow
+
+For a planning update task:
+
+1. `findSectionsByHeading` with `今回のスプリントのタスク`
+2. `listDocumentTables`
+3. identify the task table below that heading
+4. `deleteTableRows` for old sprint task rows except header
+5. `appendTableRows` with new sprint tasks
+6. `updateTableColumnWidth` for the expected layout
+7. `updateTableCellStyle` on header row with blue background
+8. `insertDateChip` or update the metadata block
+9. `listSmartChips` and `getTableStructure` to verify
+
+## 14. Recommended First Implementation Slice
+
+If implementation time is limited, build this slice first:
+
+1. `listDocumentTables`
+2. `getTableStructure`
+3. `replaceTableRowData`
+4. `appendTableRows`
+5. `deleteTableRows`
+6. `updateTableCellStyle`
+7. `updateTableColumnWidth`
+8. `cloneTable`
+9. `insertDateChip`
+
+This slice unlocks nearly all planning-doc formatting use cases.
+
+## 15. Open Questions
+
+1. Which Google Docs API fields are available for cell background, borders, and dimensions in the current `googleapis` client version?
+2. Can smart chips be inserted directly through Docs API requests, or is there any unsupported chip type requiring fallback behavior?
+3. Should template cloning be exposed as a public MCP tool, or remain an internal helper behind a higher-level `updatePlanningDocumentFromTemplate` tool?
+4. Should verification return raw structural data only, or also provide a rendered-quality heuristic?
+
+## 16. Recommendation
+
+Implement this feature set incrementally, but do not continue using full-document Markdown replacement for planning documents that depend on rich formatting.
+
+For planning docs, the preferred long-term architecture is:
+
+- template-aware
+- table-aware
+- chip-aware
+- patch-based
+
+That is the only reliable path to produce output that matches manually formatted Google Docs expectations.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "node ./dist/index.js",
     "build": "tsc",
     "test": "vitest run",
+    "test:live:docs": "vitest run src/tools/docs/cloneTable.live.test.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepublishOnly": "npm run build"

--- a/src/googleDocsApiHelpers.tableFormatting.test.ts
+++ b/src/googleDocsApiHelpers.tableFormatting.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTableCellStyleRequest,
+  buildTableBorder,
+  buildTableColumnWidthRequest,
+  buildTableRowStyleRequest,
+  buildPinTableHeaderRowsRequest,
+} from './googleDocsApiHelpers.js';
+import { hexToRgbColor } from './types.js';
+
+describe('table formatting request builders', () => {
+  it('builds updateTableCellStyle requests with range and fields', () => {
+    const border = buildTableBorder(hexToRgbColor('#000000')!, 1, 'SOLID');
+    const result = buildTableCellStyleRequest(
+      25,
+      0,
+      0,
+      {
+        rowSpan: 2,
+        columnSpan: 3,
+        backgroundColor: hexToRgbColor('#D9E2F3')!,
+        contentAlignment: 'CENTER',
+        paddingTopPt: 8,
+        borderTop: border,
+      },
+      'tab-1'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.fields).toEqual([
+      'backgroundColor',
+      'contentAlignment',
+      'paddingTop',
+      'borderTop',
+    ]);
+    expect(
+      result!.request.updateTableCellStyle!.tableRange!.tableCellLocation!.tableStartLocation
+    ).toEqual({
+      index: 25,
+      tabId: 'tab-1',
+    });
+    expect(result!.request.updateTableCellStyle!.tableRange!.rowSpan).toBe(2);
+    expect(result!.request.updateTableCellStyle!.tableRange!.columnSpan).toBe(3);
+  });
+
+  it('builds fixed-width column property requests', () => {
+    const request = buildTableColumnWidthRequest(50, [0, 2], 120, 'tab-2');
+    const props: any = request.updateTableColumnProperties;
+
+    expect(props.tableStartLocation).toEqual({ index: 50, tabId: 'tab-2' });
+    expect(props.columnIndices).toEqual([0, 2]);
+    expect(props.tableColumnProperties.widthType).toBe('FIXED_WIDTH');
+    expect(props.tableColumnProperties.width).toEqual({ magnitude: 120, unit: 'PT' });
+  });
+
+  it('builds row style requests only when fields are provided', () => {
+    const request = buildTableRowStyleRequest(75, [0, 1], 36, true, 'tab-3') as any;
+
+    expect(request.updateTableRowStyle.tableStartLocation).toEqual({ index: 75, tabId: 'tab-3' });
+    expect(request.updateTableRowStyle.rowIndices).toEqual([0, 1]);
+    expect(request.updateTableRowStyle.tableRowStyle.minRowHeight).toEqual({
+      magnitude: 36,
+      unit: 'PT',
+    });
+    expect(request.updateTableRowStyle.tableRowStyle.preventOverflow).toBe(true);
+    expect(request.updateTableRowStyle.fields).toBe('minRowHeight,preventOverflow');
+    expect(buildTableRowStyleRequest(10, [0], undefined, undefined)).toBeNull();
+  });
+
+  it('builds pinTableHeaderRows requests', () => {
+    const request: any = buildPinTableHeaderRowsRequest(99, 1, 'tab-4');
+    expect(request.pinTableHeaderRows.tableStartLocation).toEqual({ index: 99, tabId: 'tab-4' });
+    expect(request.pinTableHeaderRows.pinnedHeaderRowsCount).toBe(1);
+  });
+});

--- a/src/googleDocsApiHelpers.ts
+++ b/src/googleDocsApiHelpers.ts
@@ -672,6 +672,227 @@ export function buildUpdateParagraphStyleRequest(
   return { request, fields: fieldsToUpdate };
 }
 
+export function buildTableStartLocation(
+  tableStartIndex: number,
+  tabId?: string
+): docs_v1.Schema$Location {
+  const location: Record<string, unknown> = { index: tableStartIndex };
+  if (tabId) {
+    location.tabId = tabId;
+  }
+  return location as docs_v1.Schema$Location;
+}
+
+export function buildInsertTableRowRequest(
+  tableStartIndex: number,
+  rowIndex: number,
+  insertBelow: boolean,
+  tabId?: string
+): docs_v1.Schema$Request {
+  return {
+    insertTableRow: {
+      tableCellLocation: {
+        tableStartLocation: buildTableStartLocation(tableStartIndex, tabId),
+        rowIndex,
+        columnIndex: 0,
+      },
+      insertBelow,
+    },
+  };
+}
+
+export function buildDeleteTableRowRequest(
+  tableStartIndex: number,
+  rowIndex: number,
+  tabId?: string
+): docs_v1.Schema$Request {
+  return {
+    deleteTableRow: {
+      tableCellLocation: {
+        tableStartLocation: buildTableStartLocation(tableStartIndex, tabId),
+        rowIndex,
+        columnIndex: 0,
+      },
+    },
+  };
+}
+
+type TableCellStyleArgs = {
+  backgroundColor?: docs_v1.Schema$RgbColor;
+  contentAlignment?: 'CONTENT_ALIGNMENT_UNSPECIFIED' | 'LEFT' | 'CENTER' | 'RIGHT';
+  rowSpan?: number;
+  columnSpan?: number;
+  paddingTopPt?: number;
+  paddingBottomPt?: number;
+  paddingLeftPt?: number;
+  paddingRightPt?: number;
+  borderTop?: docs_v1.Schema$TableCellBorder;
+  borderBottom?: docs_v1.Schema$TableCellBorder;
+  borderLeft?: docs_v1.Schema$TableCellBorder;
+  borderRight?: docs_v1.Schema$TableCellBorder;
+};
+
+function pointDimension(magnitude: number): docs_v1.Schema$Dimension {
+  return { magnitude, unit: 'PT' };
+}
+
+export function buildTableCellStyleRequest(
+  tableStartIndex: number,
+  rowIndex: number,
+  columnIndex: number,
+  style: TableCellStyleArgs,
+  tabId?: string
+): { request: docs_v1.Schema$Request; fields: string[] } | null {
+  const tableCellStyle: Record<string, unknown> = {};
+  const fields: string[] = [];
+
+  if (style.backgroundColor) {
+    tableCellStyle.backgroundColor = { color: { rgbColor: style.backgroundColor } };
+    fields.push('backgroundColor');
+  }
+  if (style.contentAlignment) {
+    tableCellStyle.contentAlignment = style.contentAlignment;
+    fields.push('contentAlignment');
+  }
+  if (style.paddingTopPt !== undefined) {
+    tableCellStyle.paddingTop = pointDimension(style.paddingTopPt);
+    fields.push('paddingTop');
+  }
+  if (style.paddingBottomPt !== undefined) {
+    tableCellStyle.paddingBottom = pointDimension(style.paddingBottomPt);
+    fields.push('paddingBottom');
+  }
+  if (style.paddingLeftPt !== undefined) {
+    tableCellStyle.paddingLeft = pointDimension(style.paddingLeftPt);
+    fields.push('paddingLeft');
+  }
+  if (style.paddingRightPt !== undefined) {
+    tableCellStyle.paddingRight = pointDimension(style.paddingRightPt);
+    fields.push('paddingRight');
+  }
+  if (style.borderTop) {
+    tableCellStyle.borderTop = style.borderTop;
+    fields.push('borderTop');
+  }
+  if (style.borderBottom) {
+    tableCellStyle.borderBottom = style.borderBottom;
+    fields.push('borderBottom');
+  }
+  if (style.borderLeft) {
+    tableCellStyle.borderLeft = style.borderLeft;
+    fields.push('borderLeft');
+  }
+  if (style.borderRight) {
+    tableCellStyle.borderRight = style.borderRight;
+    fields.push('borderRight');
+  }
+
+  if (fields.length === 0) return null;
+
+  const rowSpan = style.rowSpan ?? 1;
+  const columnSpan = style.columnSpan ?? 1;
+
+  return {
+    request: {
+      updateTableCellStyle: {
+        tableRange: {
+          tableCellLocation: {
+            tableStartLocation: buildTableStartLocation(tableStartIndex, tabId),
+            rowIndex,
+            columnIndex,
+          },
+          rowSpan,
+          columnSpan,
+        },
+        tableCellStyle: tableCellStyle as docs_v1.Schema$TableCellStyle,
+        fields: fields.join(','),
+      },
+    },
+    fields,
+  };
+}
+
+export function buildTableBorder(
+  color: docs_v1.Schema$RgbColor,
+  widthPt: number,
+  dashStyle: 'SOLID' | 'DASHED' | 'DOTTED'
+): docs_v1.Schema$TableCellBorder {
+  return {
+    color: { color: { rgbColor: color } },
+    width: pointDimension(widthPt),
+    dashStyle,
+  };
+}
+
+export function buildTableColumnWidthRequest(
+  tableStartIndex: number,
+  columnIndices: number[],
+  widthPt: number,
+  tabId?: string
+): docs_v1.Schema$Request {
+  const request: any = {
+    updateTableColumnProperties: {
+      tableStartLocation: buildTableStartLocation(tableStartIndex, tabId),
+      columnIndices,
+      tableColumnProperties: {
+        widthType: 'FIXED_WIDTH',
+        width: pointDimension(widthPt),
+      },
+      fields: 'widthType,width',
+    },
+  };
+
+  return request as docs_v1.Schema$Request;
+}
+
+export function buildTableRowStyleRequest(
+  tableStartIndex: number,
+  rowIndices: number[],
+  minRowHeightPt: number | undefined,
+  preventOverflow: boolean | undefined,
+  tabId?: string
+): docs_v1.Schema$Request | null {
+  const tableRowStyle: Record<string, unknown> = {};
+  const fields: string[] = [];
+
+  if (minRowHeightPt !== undefined) {
+    tableRowStyle.minRowHeight = pointDimension(minRowHeightPt);
+    fields.push('minRowHeight');
+  }
+  if (preventOverflow !== undefined) {
+    tableRowStyle.preventOverflow = preventOverflow;
+    fields.push('preventOverflow');
+  }
+
+  if (fields.length === 0) return null;
+
+  const request: any = {
+    updateTableRowStyle: {
+      tableStartLocation: buildTableStartLocation(tableStartIndex, tabId),
+      rowIndices,
+      tableRowStyle,
+      fields: fields.join(','),
+    },
+  };
+
+  return request as docs_v1.Schema$Request;
+}
+
+export function buildPinTableHeaderRowsRequest(
+  tableStartIndex: number,
+  pinnedHeaderRowsCount: number,
+  tabId?: string
+): docs_v1.Schema$Request {
+  const request: any = {
+    pinTableHeaderRows: {
+      tableStartLocation: buildTableStartLocation(tableStartIndex, tabId),
+      pinnedHeaderRowsCount,
+    },
+  };
+
+  return request as docs_v1.Schema$Request;
+}
+
 // --- Specific Feature Helpers ---
 
 export async function createTable(

--- a/src/tools/docs/README.md
+++ b/src/tools/docs/README.md
@@ -26,20 +26,35 @@ docs/
 
 ## Structure
 
-| Tool                 | Description                                                                             |
-| -------------------- | --------------------------------------------------------------------------------------- |
-| `insertTable`        | Inserts an empty table at a character index                                             |
-| `insertPageBreak`    | Inserts a page break at a character index                                               |
-| `insertSectionBreak` | Inserts a section break (NEXT_PAGE or CONTINUOUS) — required before changing page style |
-| `updateSectionStyle` | Updates section style: flip page orientation (landscape), margins, page numbering, etc. |
-| `insertImage`        | Inserts an image from a URL or local file path                                          |
+| Tool                    | Description                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `insertTable`           | Inserts an empty table at a character index                                                                  |
+| `insertDateChip`        | Inserts a real Google Docs date smart chip at a character index                                              |
+| `insertPerson`          | Inserts a Google Docs person smart chip using an email address                                               |
+| `insertRichLink`        | Inserts a Google Docs rich-link smart chip for a Google resource                                             |
+| `listSmartChips`        | Lists date, person, and rich-link smart chips found in the document                                          |
+| `cloneTable`            | Clones a source table into a target document while preserving widths and table-level styling where supported |
+| `listDocumentTables`    | Lists tables in a document with MCP table IDs                                                                |
+| `getTableStructure`     | Returns row/column/cell structure for a table                                                                |
+| `findSectionsByHeading` | Finds heading sections and the table that follows them                                                       |
+| `replaceTableRowData`   | Replaces the contents of an existing table row                                                               |
+| `appendTableRows`       | Appends rows to an existing table without replacing the whole document                                       |
+| `deleteTableRows`       | Deletes one or more rows from an existing table                                                              |
+| `insertPageBreak`       | Inserts a page break at a character index                                                                    |
+| `insertSectionBreak`    | Inserts a section break (NEXT_PAGE or CONTINUOUS) — required before changing page style                      |
+| `updateSectionStyle`    | Updates section style: flip page orientation (landscape), margins, page numbering, etc.                      |
+| `insertImage`           | Inserts an image from a URL or local file path                                                               |
 
 ## [Formatting](./formatting/)
 
-| Tool                  | Description                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------- |
-| `applyTextStyle`      | Applies character-level formatting (bold, color, font, etc.) to a range or found text |
-| `applyParagraphStyle` | Applies paragraph-level formatting (alignment, spacing, heading styles)               |
+| Tool                     | Description                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------- |
+| `applyTextStyle`         | Applies character-level formatting (bold, color, font, etc.) to a range or found text |
+| `applyParagraphStyle`    | Applies paragraph-level formatting (alignment, spacing, heading styles)               |
+| `updateTableCellStyle`   | Applies background, padding, and alignment to a table cell range                      |
+| `updateTableBorders`     | Applies border styles to a table cell range                                           |
+| `updateTableColumnWidth` | Sets fixed widths for one or more table columns                                       |
+| `updateTableRowStyle`    | Applies row-level styling and optional pinned header rows                             |
 
 ## [Comments](./comments/)
 

--- a/src/tools/docs/appendTableRows.ts
+++ b/src/tools/docs/appendTableRows.ts
@@ -36,57 +36,58 @@ export function register(server: FastMCP) {
       );
 
       try {
-        for (const [offset, rowValues] of args.rows.entries()) {
-          const res = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields:
-              'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
-          });
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+        });
 
-          const table = getTableById(res.data, args.tableId, args.tabId);
-          if (!table) {
-            throw new UserError(`Table "${args.tableId}" not found in document.`);
-          }
-          if (table.startIndex == null) {
-            throw new UserError(
-              `Table "${args.tableId}" does not expose a valid table start index.`
-            );
-          }
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) {
+          throw new UserError(`Table "${args.tableId}" not found in document.`);
+        }
+        if (table.startIndex == null) {
+          throw new UserError(`Table "${args.tableId}" does not expose a valid table start index.`);
+        }
+
+        for (const [offset, rowValues] of args.rows.entries()) {
           if (rowValues.length > table.columnCount) {
             throw new UserError(
               `Row ${offset} has ${rowValues.length} values, but table ${args.tableId} only has ${table.columnCount} columns.`
             );
           }
+        }
 
-          await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [
-            GDocsHelpers.buildInsertTableRowRequest(
-              table.startIndex,
-              table.rowCount - 1,
-              true,
-              args.tabId
-            ),
-          ]);
+        const insertRequests = args.rows.map(() =>
+          GDocsHelpers.buildInsertTableRowRequest(table.startIndex!, table.rowCount - 1, true, args.tabId)
+        );
+        await GDocsHelpers.executeBatchUpdateWithSplitting(
+          docs,
+          args.documentId,
+          insertRequests,
+          log
+        );
 
-          const refreshed = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields:
-              'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
-          });
+        const refreshed = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+        });
 
-          const updatedTable = getTableById(refreshed.data, args.tableId, args.tabId);
-          if (!updatedTable) {
-            throw new UserError(
-              `Table "${args.tableId}" could not be found after appending a row.`
-            );
-          }
+        const updatedTable = getTableById(refreshed.data, args.tableId, args.tabId);
+        if (!updatedTable) {
+          throw new UserError(`Table "${args.tableId}" could not be found after appending rows.`);
+        }
 
+        const firstAppendedRowIndex = table.rowCount;
+        for (const [offset, rowValues] of args.rows.entries()) {
           await replaceTableRowDataInternal(
             docs,
             args.documentId,
             updatedTable,
-            updatedTable.rowCount - 1,
+            firstAppendedRowIndex + offset,
             rowValues,
             args.tabId
           );

--- a/src/tools/docs/appendTableRows.ts
+++ b/src/tools/docs/appendTableRows.ts
@@ -1,0 +1,108 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { DocumentIdParameter } from '../../types.js';
+import { getTableById } from './structureHelpers.js';
+import { replaceTableRowData as replaceTableRowDataInternal } from './tableRowDataHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'appendTableRows',
+    description:
+      'Appends one or more plain-text rows to the end of an existing Google Docs table while preserving the table structure.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z
+        .string()
+        .min(1)
+        .describe('The MCP table ID returned by listDocumentTables, for example "table:body:0".'),
+      rows: z
+        .array(z.array(z.string()).max(50))
+        .min(1)
+        .max(200)
+        .describe('Rows to append. Each inner array is the plain-text cell values for one row.'),
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab containing the table. If not specified, uses the first tab or legacy document body.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Appending ${args.rows.length} row(s) to ${args.tableId} in doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        for (const [offset, rowValues] of args.rows.entries()) {
+          const res = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields:
+              'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+          });
+
+          const table = getTableById(res.data, args.tableId, args.tabId);
+          if (!table) {
+            throw new UserError(`Table "${args.tableId}" not found in document.`);
+          }
+          if (table.startIndex == null) {
+            throw new UserError(
+              `Table "${args.tableId}" does not expose a valid table start index.`
+            );
+          }
+          if (rowValues.length > table.columnCount) {
+            throw new UserError(
+              `Row ${offset} has ${rowValues.length} values, but table ${args.tableId} only has ${table.columnCount} columns.`
+            );
+          }
+
+          await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [
+            GDocsHelpers.buildInsertTableRowRequest(
+              table.startIndex,
+              table.rowCount - 1,
+              true,
+              args.tabId
+            ),
+          ]);
+
+          const refreshed = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields:
+              'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+          });
+
+          const updatedTable = getTableById(refreshed.data, args.tableId, args.tabId);
+          if (!updatedTable) {
+            throw new UserError(
+              `Table "${args.tableId}" could not be found after appending a row.`
+            );
+          }
+
+          await replaceTableRowDataInternal(
+            docs,
+            args.documentId,
+            updatedTable,
+            updatedTable.rowCount - 1,
+            rowValues,
+            args.tabId
+          );
+        }
+
+        return `Successfully appended ${args.rows.length} row(s) to table ${args.tableId}.`;
+      } catch (error: any) {
+        log.error(
+          `Error appending rows to ${args.tableId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(`Failed to append table rows: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/appendTableRows.ts
+++ b/src/tools/docs/appendTableRows.ts
@@ -60,7 +60,12 @@ export function register(server: FastMCP) {
         }
 
         const insertRequests = args.rows.map(() =>
-          GDocsHelpers.buildInsertTableRowRequest(table.startIndex!, table.rowCount - 1, true, args.tabId)
+          GDocsHelpers.buildInsertTableRowRequest(
+            table.startIndex!,
+            table.rowCount - 1,
+            true,
+            args.tabId
+          )
         );
         await GDocsHelpers.executeBatchUpdateWithSplitting(
           docs,

--- a/src/tools/docs/cloneTable.live.test.ts
+++ b/src/tools/docs/cloneTable.live.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { getDocsClient, getDriveClient } from '../../clients.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { buildInsertTableWithDataRequests } from './insertTableWithData.js';
+import { extractTableSnapshot } from './structureHelpers.js';
+import { register as registerCloneTable } from './cloneTable.js';
+import { hexToRgbColor } from '../../types.js';
+
+const runLive = process.env.GOOGLE_DOCS_LIVE_TESTS === '1';
+const liveDescribe = runLive ? describe : describe.skip;
+
+const mockLog = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+let toolExecute: (args: any, context: any) => Promise<string>;
+
+const TABLE_FIELDS =
+  'body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))))';
+
+liveDescribe('cloneTable live integration', () => {
+  const createdDocumentIds: string[] = [];
+
+  beforeAll(() => {
+    const fakeServer = { addTool: (config: any) => (toolExecute = config.execute) };
+    registerCloneTable(fakeServer as any);
+  });
+
+  afterEach(async () => {
+    const drive = await getDriveClient();
+    while (createdDocumentIds.length > 0) {
+      const fileId = createdDocumentIds.pop()!;
+      try {
+        await drive.files.delete({ fileId, supportsAllDrives: true });
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+  });
+
+  it('clones a formatted table into a target document and preserves core formatting', async () => {
+    const drive = await getDriveClient();
+    const docs = await getDocsClient();
+
+    const sourceDoc = await drive.files.create({
+      requestBody: {
+        name: `cloneTable-source-${Date.now()}`,
+        mimeType: 'application/vnd.google-apps.document',
+      },
+      fields: 'id',
+      supportsAllDrives: true,
+    });
+    const targetDoc = await drive.files.create({
+      requestBody: {
+        name: `cloneTable-target-${Date.now()}`,
+        mimeType: 'application/vnd.google-apps.document',
+      },
+      fields: 'id',
+      supportsAllDrives: true,
+    });
+
+    const sourceDocumentId = sourceDoc.data.id!;
+    const targetDocumentId = targetDoc.data.id!;
+    createdDocumentIds.push(sourceDocumentId, targetDocumentId);
+
+    const sourceData = [
+      ['No.', '課題名'],
+      ['1', 'SHIN-2870 調査'],
+    ];
+
+    await GDocsHelpers.executeBatchUpdateWithSplitting(
+      docs,
+      sourceDocumentId,
+      buildInsertTableWithDataRequests(sourceData, 1, true),
+      mockLog
+    );
+
+    const sourceTableStart = 2;
+    const styleRequests = [
+      GDocsHelpers.buildTableColumnWidthRequest(sourceTableStart, [0], 60),
+      GDocsHelpers.buildTableColumnWidthRequest(sourceTableStart, [1], 180),
+      GDocsHelpers.buildPinTableHeaderRowsRequest(sourceTableStart, 1),
+      GDocsHelpers.buildTableRowStyleRequest(sourceTableStart, [0], 24, true),
+    ].filter(Boolean);
+
+    const headerBg = hexToRgbColor('#D9E2F3')!;
+    const headerCellStyle = GDocsHelpers.buildTableCellStyleRequest(sourceTableStart, 0, 0, {
+      rowSpan: 1,
+      columnSpan: 2,
+      backgroundColor: headerBg,
+      contentAlignment: 'CENTER',
+      paddingTopPt: 6,
+      paddingBottomPt: 6,
+    });
+    if (headerCellStyle) styleRequests.push(headerCellStyle.request);
+
+    await GDocsHelpers.executeBatchUpdateWithSplitting(
+      docs,
+      sourceDocumentId,
+      styleRequests,
+      mockLog
+    );
+
+    await toolExecute(
+      {
+        documentId: targetDocumentId,
+        sourceDocumentId,
+        sourceTableId: 'table:body:0',
+        index: 1,
+      },
+      { log: mockLog }
+    );
+
+    const targetRes = await docs.documents.get({
+      documentId: targetDocumentId,
+      fields: TABLE_FIELDS,
+    });
+
+    const snapshot = extractTableSnapshot(targetRes.data, 'table:body:0');
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.data).toEqual(sourceData);
+    expect(snapshot!.pinnedHeaderRowsCount).toBe(1);
+    expect(snapshot!.columnStyles).toEqual([
+      { columnIndex: 0, widthPt: 60, widthType: 'FIXED_WIDTH' },
+      { columnIndex: 1, widthPt: 180, widthType: 'FIXED_WIDTH' },
+    ]);
+    expect(snapshot!.rowStyles[0]).toMatchObject({
+      rowIndex: 0,
+      minRowHeightPt: 24,
+      preventOverflow: true,
+      tableHeader: true,
+    });
+    expect(snapshot!.cellStyles[0]).toMatchObject({
+      rowIndex: 0,
+      columnIndex: 0,
+      contentAlignment: 'CENTER',
+      paddingTopPt: 6,
+      paddingBottomPt: 6,
+      hasBoldText: true,
+    });
+  }, 120000);
+});

--- a/src/tools/docs/cloneTable.test.ts
+++ b/src/tools/docs/cloneTable.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { extractTableSnapshot, findTableNearestStartIndex } from './structureHelpers.js';
+
+const mockDocument = {
+  body: {
+    content: [
+      {
+        startIndex: 10,
+        endIndex: 100,
+        table: {
+          rows: 2,
+          columns: 2,
+          tableStyle: {
+            tableColumnProperties: [
+              { widthType: 'FIXED_WIDTH', width: { magnitude: 60, unit: 'PT' } },
+              { widthType: 'FIXED_WIDTH', width: { magnitude: 180, unit: 'PT' } },
+            ],
+          },
+          tableRows: [
+            {
+              tableRowStyle: {
+                minRowHeight: { magnitude: 24, unit: 'PT' },
+                tableHeader: true,
+              },
+              tableCells: [
+                {
+                  startIndex: 15,
+                  endIndex: 25,
+                  tableCellStyle: {
+                    backgroundColor: { color: { rgbColor: { red: 0.85, green: 0.9, blue: 0.95 } } },
+                    contentAlignment: 'CENTER',
+                    paddingTop: { magnitude: 6, unit: 'PT' },
+                  },
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [
+                          {
+                            startIndex: 16,
+                            endIndex: 19,
+                            textRun: {
+                              content: 'No.\n',
+                              textStyle: { bold: true },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                {
+                  startIndex: 25,
+                  endIndex: 45,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [
+                          {
+                            startIndex: 26,
+                            endIndex: 30,
+                            textRun: {
+                              content: '課題名\n',
+                              textStyle: { bold: true },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              tableCells: [
+                {
+                  startIndex: 45,
+                  endIndex: 55,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [{ startIndex: 46, endIndex: 47, textRun: { content: '1\n' } }],
+                      },
+                    },
+                  ],
+                },
+                {
+                  startIndex: 55,
+                  endIndex: 95,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [
+                          {
+                            startIndex: 56,
+                            endIndex: 69,
+                            textRun: { content: 'SHIN-2870 調査\n' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        startIndex: 120,
+        endIndex: 180,
+        table: {
+          rows: 1,
+          columns: 1,
+          tableRows: [
+            {
+              tableCells: [
+                {
+                  startIndex: 125,
+                  endIndex: 135,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [{ startIndex: 126, endIndex: 130, textRun: { content: 'X\n' } }],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  },
+} as any;
+
+describe('table snapshot helpers', () => {
+  it('extracts a reusable table snapshot with styles', () => {
+    const snapshot = extractTableSnapshot(mockDocument, 'table:body:0');
+
+    expect(snapshot).toMatchObject({
+      tableId: 'table:body:0',
+      rowCount: 2,
+      columnCount: 2,
+      pinnedHeaderRowsCount: 1,
+      data: [
+        ['No.', '課題名'],
+        ['1', 'SHIN-2870 調査'],
+      ],
+      columnStyles: [
+        { columnIndex: 0, widthPt: 60, widthType: 'FIXED_WIDTH' },
+        { columnIndex: 1, widthPt: 180, widthType: 'FIXED_WIDTH' },
+      ],
+    });
+    expect(snapshot?.rowStyles[0]).toMatchObject({
+      rowIndex: 0,
+      minRowHeightPt: 24,
+      tableHeader: true,
+    });
+    expect(snapshot?.cellStyles[0]).toMatchObject({
+      rowIndex: 0,
+      columnIndex: 0,
+      contentAlignment: 'CENTER',
+      paddingTopPt: 6,
+      hasBoldText: true,
+    });
+  });
+
+  it('finds the table nearest to an insertion index', () => {
+    const table = findTableNearestStartIndex(mockDocument, 100);
+    expect(table?.tableId).toBe('table:body:1');
+  });
+});

--- a/src/tools/docs/cloneTable.ts
+++ b/src/tools/docs/cloneTable.ts
@@ -1,0 +1,236 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { docs_v1 } from 'googleapis';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { buildInsertTableWithDataRequests } from './insertTableWithData.js';
+import {
+  extractTableSnapshot,
+  findTableNearestStartIndex,
+  getTableById,
+} from './structureHelpers.js';
+
+const CloneTableParameters = DocumentIdParameter.extend({
+  sourceDocumentId: z.string().min(1).describe('Document ID containing the source table template.'),
+  sourceTableId: z.string().min(1).describe('Source MCP table ID from listDocumentTables.'),
+  index: z
+    .number()
+    .int()
+    .min(1)
+    .describe(
+      '1-based character index in the target document where the cloned table should be inserted.'
+    ),
+  sourceTabId: z.string().optional().describe('Optional tab ID for the source document table.'),
+  targetTabId: z
+    .string()
+    .optional()
+    .describe('Optional tab ID for the target document insertion point.'),
+  copyColumnWidths: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Copy fixed column widths from the source table.'),
+  copyRowStyles: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Copy row min height and overflow settings from the source table.'),
+  copyCellStyles: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Copy cell-level formatting such as background, padding, alignment, and borders.'),
+  copyPinnedHeaderRows: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Copy pinned header rows from the source table when present.'),
+  copyHeaderBold: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Apply bold text to cloned cells whose source cell text was bold.'),
+});
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'cloneTable',
+    description:
+      'Clones a source Google Docs table into a target document, preserving text, column widths, row styles, cell styles, and pinned header rows where supported.',
+    parameters: CloneTableParameters,
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Cloning table ${args.sourceTableId} from ${args.sourceDocumentId} into ${args.documentId} at index ${args.index}`
+      );
+
+      try {
+        const sourceRes = await docs.documents.get({
+          documentId: args.sourceDocumentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))),paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan))))))))',
+        });
+
+        const snapshot = extractTableSnapshot(sourceRes.data, args.sourceTableId, args.sourceTabId);
+        if (!snapshot) {
+          throw new UserError(
+            `Source table "${args.sourceTableId}" was not found in source document ${args.sourceDocumentId}.`
+          );
+        }
+        if (snapshot.rowCount === 0 || snapshot.columnCount === 0) {
+          throw new UserError(
+            `Source table "${args.sourceTableId}" is empty and cannot be cloned.`
+          );
+        }
+
+        if (args.targetTabId) {
+          const targetInfo = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields: 'tabs(tabProperties,documentTab)',
+          });
+          const targetTab = GDocsHelpers.findTabById(targetInfo.data, args.targetTabId);
+          if (!targetTab)
+            throw new UserError(`Target tab "${args.targetTabId}" not found in document.`);
+          if (!targetTab.documentTab) {
+            throw new UserError(`Target tab "${args.targetTabId}" does not have document content.`);
+          }
+        }
+
+        const insertRequests = buildInsertTableWithDataRequests(
+          snapshot.data,
+          args.index,
+          false,
+          args.targetTabId
+        );
+        await GDocsHelpers.executeBatchUpdateWithSplitting(
+          docs,
+          args.documentId,
+          insertRequests,
+          log
+        );
+
+        const targetRes = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+        });
+
+        const targetTable =
+          findTableNearestStartIndex(targetRes.data, args.index, args.targetTabId) ??
+          getTableById(targetRes.data, args.sourceTableId, args.targetTabId);
+        if (!targetTable || targetTable.startIndex == null) {
+          throw new UserError(
+            'Cloned target table was inserted, but could not be re-located for style copying.'
+          );
+        }
+
+        const styleRequests: docs_v1.Schema$Request[] = [];
+
+        if (args.copyColumnWidths) {
+          for (const columnStyle of snapshot.columnStyles) {
+            if (columnStyle.widthType !== 'FIXED_WIDTH' || !columnStyle.widthPt) continue;
+            styleRequests.push(
+              GDocsHelpers.buildTableColumnWidthRequest(
+                targetTable.startIndex,
+                [columnStyle.columnIndex],
+                columnStyle.widthPt,
+                args.targetTabId
+              )
+            );
+          }
+        }
+
+        if (args.copyRowStyles) {
+          for (const rowStyle of snapshot.rowStyles) {
+            const request = GDocsHelpers.buildTableRowStyleRequest(
+              targetTable.startIndex,
+              [rowStyle.rowIndex],
+              rowStyle.minRowHeightPt,
+              rowStyle.preventOverflow,
+              args.targetTabId
+            );
+            if (request) styleRequests.push(request);
+          }
+        }
+
+        if (args.copyPinnedHeaderRows && snapshot.pinnedHeaderRowsCount > 0) {
+          styleRequests.push(
+            GDocsHelpers.buildPinTableHeaderRowsRequest(
+              targetTable.startIndex,
+              snapshot.pinnedHeaderRowsCount,
+              args.targetTabId
+            )
+          );
+        }
+
+        if (args.copyCellStyles) {
+          for (const cellStyle of snapshot.cellStyles) {
+            const requestInfo = GDocsHelpers.buildTableCellStyleRequest(
+              targetTable.startIndex,
+              cellStyle.rowIndex,
+              cellStyle.columnIndex,
+              {
+                backgroundColor: cellStyle.backgroundColor,
+                contentAlignment: cellStyle.contentAlignment ?? undefined,
+                paddingTopPt: cellStyle.paddingTopPt,
+                paddingBottomPt: cellStyle.paddingBottomPt,
+                paddingLeftPt: cellStyle.paddingLeftPt,
+                paddingRightPt: cellStyle.paddingRightPt,
+                borderTop: cellStyle.borderTop,
+                borderBottom: cellStyle.borderBottom,
+                borderLeft: cellStyle.borderLeft,
+                borderRight: cellStyle.borderRight,
+              },
+              args.targetTabId
+            );
+            if (requestInfo) styleRequests.push(requestInfo.request);
+          }
+        }
+
+        if (args.copyHeaderBold) {
+          for (const cellStyle of snapshot.cellStyles) {
+            if (!cellStyle.hasBoldText) continue;
+            const targetCell = targetTable.cells.find(
+              (cell) =>
+                cell.rowIndex === cellStyle.rowIndex && cell.columnIndex === cellStyle.columnIndex
+            );
+            if (!targetCell?.contentStartIndex) continue;
+
+            const targetText = snapshot.data[cellStyle.rowIndex]?.[cellStyle.columnIndex] ?? '';
+            if (!targetText) continue;
+
+            const requestInfo = GDocsHelpers.buildUpdateTextStyleRequest(
+              targetCell.contentStartIndex,
+              targetCell.contentStartIndex + targetText.length,
+              { bold: true },
+              args.targetTabId
+            );
+            if (requestInfo) styleRequests.push(requestInfo.request);
+          }
+        }
+
+        if (styleRequests.length > 0) {
+          await GDocsHelpers.executeBatchUpdateWithSplitting(
+            docs,
+            args.documentId,
+            styleRequests,
+            log
+          );
+        }
+
+        return `Successfully cloned ${args.sourceTableId} into ${args.documentId} at index ${args.index}.`;
+      } catch (error: any) {
+        log.error(
+          `Error cloning table ${args.sourceTableId} from ${args.sourceDocumentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to clone table: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/cloneTable.ts
+++ b/src/tools/docs/cloneTable.ts
@@ -6,10 +6,7 @@ import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { buildInsertTableWithDataRequests } from './insertTableWithData.js';
-import {
-  extractDocumentTables,
-  extractTableSnapshot,
-} from './structureHelpers.js';
+import { extractDocumentTables, extractTableSnapshot } from './structureHelpers.js';
 
 const CloneTableParameters = DocumentIdParameter.extend({
   sourceDocumentId: z.string().min(1).describe('Document ID containing the source table template.'),
@@ -127,7 +124,10 @@ export function register(server: FastMCP) {
               table.rowCount === snapshot.rowCount &&
               table.columnCount === snapshot.columnCount
           )
-          .sort((a, b) => (a.startIndex ?? Number.MAX_SAFE_INTEGER) - (b.startIndex ?? Number.MAX_SAFE_INTEGER))[0];
+          .sort(
+            (a, b) =>
+              (a.startIndex ?? Number.MAX_SAFE_INTEGER) - (b.startIndex ?? Number.MAX_SAFE_INTEGER)
+          )[0];
         if (!targetTable || targetTable.startIndex == null) {
           throw new UserError(
             'Cloned target table was inserted, but could not be re-located safely for style copying.'

--- a/src/tools/docs/cloneTable.ts
+++ b/src/tools/docs/cloneTable.ts
@@ -7,9 +7,8 @@ import { DocumentIdParameter } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { buildInsertTableWithDataRequests } from './insertTableWithData.js';
 import {
+  extractDocumentTables,
   extractTableSnapshot,
-  findTableNearestStartIndex,
-  getTableById,
 } from './structureHelpers.js';
 
 const CloneTableParameters = DocumentIdParameter.extend({
@@ -120,12 +119,18 @@ export function register(server: FastMCP) {
             'body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
         });
 
-        const targetTable =
-          findTableNearestStartIndex(targetRes.data, args.index, args.targetTabId) ??
-          getTableById(targetRes.data, args.sourceTableId, args.targetTabId);
+        const targetTable = extractDocumentTables(targetRes.data, args.targetTabId)
+          .filter(
+            (table) =>
+              table.startIndex != null &&
+              table.startIndex >= args.index &&
+              table.rowCount === snapshot.rowCount &&
+              table.columnCount === snapshot.columnCount
+          )
+          .sort((a, b) => (a.startIndex ?? Number.MAX_SAFE_INTEGER) - (b.startIndex ?? Number.MAX_SAFE_INTEGER))[0];
         if (!targetTable || targetTable.startIndex == null) {
           throw new UserError(
-            'Cloned target table was inserted, but could not be re-located for style copying.'
+            'Cloned target table was inserted, but could not be re-located safely for style copying.'
           );
         }
 

--- a/src/tools/docs/deleteTableRows.ts
+++ b/src/tools/docs/deleteTableRows.ts
@@ -1,0 +1,80 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { getTableById } from './structureHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'deleteTableRows',
+    description:
+      'Deletes one or more rows from an existing Google Docs table without replacing the whole document.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z
+        .string()
+        .min(1)
+        .describe('The MCP table ID returned by listDocumentTables, for example "table:body:0".'),
+      rowStart: z.number().int().min(0).describe('Zero-based starting row index to delete.'),
+      rowCount: z.number().int().min(1).describe('Number of rows to delete.'),
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab containing the table. If not specified, uses the first tab or legacy document body.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Deleting ${args.rowCount} row(s) from ${args.tableId} in doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))))',
+        });
+
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) {
+          throw new UserError(`Table "${args.tableId}" not found in document.`);
+        }
+        if (table.startIndex == null) {
+          throw new UserError(`Table "${args.tableId}" does not expose a valid table start index.`);
+        }
+        if (args.rowStart + args.rowCount > table.rowCount) {
+          throw new UserError(
+            `Requested rows ${args.rowStart}-${args.rowStart + args.rowCount - 1} exceed table ${args.tableId} row count ${table.rowCount}.`
+          );
+        }
+
+        const requests = [];
+        for (
+          let rowIndex = args.rowStart + args.rowCount - 1;
+          rowIndex >= args.rowStart;
+          rowIndex--
+        ) {
+          requests.push(
+            GDocsHelpers.buildDeleteTableRowRequest(table.startIndex, rowIndex, args.tabId)
+          );
+        }
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, requests);
+        return `Successfully deleted ${args.rowCount} row(s) from table ${args.tableId}.`;
+      } catch (error: any) {
+        log.error(
+          `Error deleting rows from ${args.tableId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(`Failed to delete table rows: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/findSectionsByHeading.ts
+++ b/src/tools/docs/findSectionsByHeading.ts
@@ -1,0 +1,56 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import { findHeadings } from './structureHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'findSectionsByHeading',
+    description:
+      'Finds heading-based sections in a Google Document and reports heading ranges plus the first table that follows each heading.',
+    parameters: DocumentIdParameter.extend({
+      headings: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(50)
+        .describe('List of exact heading texts to locate in the document.'),
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab to inspect. If not specified, inspects the first tab or legacy document body.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Finding sections by heading in ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}: ${args.headings.join(', ')}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,paragraph(paragraphStyle(namedStyleType),elements(textRun(content))),table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,paragraph(paragraphStyle(namedStyleType),elements(textRun(content))),table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))))',
+        });
+
+        const sections = findHeadings(res.data, args.headings, args.tabId);
+        return JSON.stringify({ sections }, null, 2);
+      } catch (error: any) {
+        log.error(
+          `Error finding sections by heading in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(
+          `Failed to find sections by heading: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/docs/formatting/index.ts
+++ b/src/tools/docs/formatting/index.ts
@@ -2,8 +2,16 @@ import type { FastMCP } from 'fastmcp';
 
 import { register as applyTextStyle } from './applyTextStyle.js';
 import { register as applyParagraphStyle } from './applyParagraphStyle.js';
+import { register as updateTableCellStyle } from './updateTableCellStyle.js';
+import { register as updateTableBorders } from './updateTableBorders.js';
+import { register as updateTableColumnWidth } from './updateTableColumnWidth.js';
+import { register as updateTableRowStyle } from './updateTableRowStyle.js';
 
 export function registerFormattingTools(server: FastMCP) {
   applyTextStyle(server);
   applyParagraphStyle(server);
+  updateTableCellStyle(server);
+  updateTableBorders(server);
+  updateTableColumnWidth(server);
+  updateTableRowStyle(server);
 }

--- a/src/tools/docs/formatting/updateTableBorders.ts
+++ b/src/tools/docs/formatting/updateTableBorders.ts
@@ -1,0 +1,107 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../../clients.js';
+import { DocumentIdParameter, validateHexColor, hexToRgbColor } from '../../../types.js';
+import { getTableById } from '../structureHelpers.js';
+import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
+
+const BorderSideSchema = z.object({
+  color: z
+    .string()
+    .refine(validateHexColor, { message: 'Invalid hex color format (e.g., #000000).' })
+    .optional(),
+  widthPt: z.number().min(0).optional(),
+  dashStyle: z.enum(['SOLID', 'DASHED', 'DOTTED']).optional(),
+});
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'updateTableBorders',
+    description:
+      'Applies table border styles to a Google Docs table range. Supports top/bottom/left/right borders across a cell range.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z.string().min(1).describe('The MCP table ID returned by listDocumentTables.'),
+      rowStart: z.number().int().min(0).describe('Zero-based starting row index.'),
+      rowEnd: z.number().int().min(0).describe('Zero-based ending row index (inclusive).'),
+      columnStart: z.number().int().min(0).describe('Zero-based starting column index.'),
+      columnEnd: z.number().int().min(0).describe('Zero-based ending column index (inclusive).'),
+      top: BorderSideSchema.optional(),
+      bottom: BorderSideSchema.optional(),
+      left: BorderSideSchema.optional(),
+      right: BorderSideSchema.optional(),
+      tabId: z.string().optional().describe('Optional target tab ID.'),
+    })
+      .refine((data) => data.rowEnd >= data.rowStart, {
+        message: 'rowEnd must be greater than or equal to rowStart',
+        path: ['rowEnd'],
+      })
+      .refine((data) => data.columnEnd >= data.columnStart, {
+        message: 'columnEnd must be greater than or equal to columnStart',
+        path: ['columnEnd'],
+      }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Updating table borders in ${args.tableId} for doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+        });
+
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) throw new UserError(`Table "${args.tableId}" not found in document.`);
+        if (table.startIndex == null) {
+          throw new UserError(`Table "${args.tableId}" does not expose a valid table start index.`);
+        }
+
+        const defaultColor = hexToRgbColor('#000000')!;
+        const makeBorder = (side?: {
+          color?: string;
+          widthPt?: number;
+          dashStyle?: 'SOLID' | 'DASHED' | 'DOTTED';
+        }) =>
+          side
+            ? GDocsHelpers.buildTableBorder(
+                hexToRgbColor(side.color ?? '#000000') ?? defaultColor,
+                side.widthPt ?? 1,
+                side.dashStyle ?? 'SOLID'
+              )
+            : undefined;
+
+        const requestInfo = GDocsHelpers.buildTableCellStyleRequest(
+          table.startIndex,
+          args.rowStart,
+          args.columnStart,
+          {
+            rowSpan: args.rowEnd - args.rowStart + 1,
+            columnSpan: args.columnEnd - args.columnStart + 1,
+            borderTop: makeBorder(args.top),
+            borderBottom: makeBorder(args.bottom),
+            borderLeft: makeBorder(args.left),
+            borderRight: makeBorder(args.right),
+          },
+          args.tabId
+        );
+
+        if (!requestInfo) {
+          throw new UserError('No border style options were provided.');
+        }
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [requestInfo.request]);
+        return `Successfully updated table borders (${requestInfo.fields.join(', ')}) for ${args.tableId}.`;
+      } catch (error: any) {
+        log.error(
+          `Error updating table borders for ${args.tableId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to update table borders: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/formatting/updateTableCellStyle.ts
+++ b/src/tools/docs/formatting/updateTableCellStyle.ts
@@ -1,0 +1,106 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../../clients.js';
+import { getTableById } from '../structureHelpers.js';
+import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
+import { DocumentIdParameter, validateHexColor, hexToRgbColor } from '../../../types.js';
+
+const HexColor = z
+  .string()
+  .refine(validateHexColor, { message: 'Invalid hex color format (e.g., #D9E2F3).' });
+
+const Alignment = z.enum(['LEFT', 'CENTER', 'RIGHT']);
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'updateTableCellStyle',
+    description:
+      'Applies cell-level formatting to a Google Docs table range, including background color, alignment, padding, and borders.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z.string().min(1).describe('The MCP table ID returned by listDocumentTables.'),
+      rowStart: z.number().int().min(0).describe('Zero-based starting row index.'),
+      rowEnd: z.number().int().min(0).describe('Zero-based ending row index (inclusive).'),
+      columnStart: z.number().int().min(0).describe('Zero-based starting column index.'),
+      columnEnd: z.number().int().min(0).describe('Zero-based ending column index (inclusive).'),
+      backgroundColor: HexColor.optional().describe('Cell background color, e.g. "#D9E2F3".'),
+      contentAlignment: Alignment.optional().describe('Horizontal content alignment inside cells.'),
+      paddingTopPt: z.number().min(0).optional().describe('Top padding in points.'),
+      paddingBottomPt: z.number().min(0).optional().describe('Bottom padding in points.'),
+      paddingLeftPt: z.number().min(0).optional().describe('Left padding in points.'),
+      paddingRightPt: z.number().min(0).optional().describe('Right padding in points.'),
+      tabId: z.string().optional().describe('Optional target tab ID.'),
+    })
+      .refine((data) => data.rowEnd >= data.rowStart, {
+        message: 'rowEnd must be greater than or equal to rowStart',
+        path: ['rowEnd'],
+      })
+      .refine((data) => data.columnEnd >= data.columnStart, {
+        message: 'columnEnd must be greater than or equal to columnStart',
+        path: ['columnEnd'],
+      }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Updating table cell style in ${args.tableId} for doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+        });
+
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) throw new UserError(`Table "${args.tableId}" not found in document.`);
+        if (table.startIndex == null) {
+          throw new UserError(`Table "${args.tableId}" does not expose a valid table start index.`);
+        }
+        if (args.rowEnd >= table.rowCount) {
+          throw new UserError(`rowEnd ${args.rowEnd} exceeds table row count ${table.rowCount}.`);
+        }
+        if (args.columnEnd >= table.columnCount) {
+          throw new UserError(
+            `columnEnd ${args.columnEnd} exceeds table column count ${table.columnCount}.`
+          );
+        }
+
+        const requestInfo = GDocsHelpers.buildTableCellStyleRequest(
+          table.startIndex,
+          args.rowStart,
+          args.columnStart,
+          {
+            rowSpan: args.rowEnd - args.rowStart + 1,
+            columnSpan: args.columnEnd - args.columnStart + 1,
+            backgroundColor: args.backgroundColor
+              ? (hexToRgbColor(args.backgroundColor) ?? undefined)
+              : undefined,
+            contentAlignment: args.contentAlignment,
+            paddingTopPt: args.paddingTopPt,
+            paddingBottomPt: args.paddingBottomPt,
+            paddingLeftPt: args.paddingLeftPt,
+            paddingRightPt: args.paddingRightPt,
+          },
+          args.tabId
+        );
+
+        if (!requestInfo) {
+          throw new UserError('No table cell style options were provided.');
+        }
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [requestInfo.request]);
+        return `Successfully updated table cell style (${requestInfo.fields.join(', ')}) for ${args.tableId}.`;
+      } catch (error: any) {
+        log.error(
+          `Error updating table cell style for ${args.tableId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Failed to update table cell style: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/docs/formatting/updateTableColumnWidth.ts
+++ b/src/tools/docs/formatting/updateTableColumnWidth.ts
@@ -1,0 +1,67 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../../clients.js';
+import { DocumentIdParameter } from '../../../types.js';
+import { getTableById } from '../structureHelpers.js';
+import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'updateTableColumnWidth',
+    description: 'Sets fixed widths for one or more columns in an existing Google Docs table.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z.string().min(1).describe('The MCP table ID returned by listDocumentTables.'),
+      columnIndices: z
+        .array(z.number().int().min(0))
+        .min(1)
+        .describe('Zero-based column indices to update.'),
+      widthPt: z.number().min(1).describe('Fixed width in points.'),
+      tabId: z.string().optional().describe('Optional target tab ID.'),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Updating table column widths in ${args.tableId} for doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+        });
+
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) throw new UserError(`Table "${args.tableId}" not found in document.`);
+        if (table.startIndex == null) {
+          throw new UserError(`Table "${args.tableId}" does not expose a valid table start index.`);
+        }
+        if (args.columnIndices.some((index) => index >= table.columnCount)) {
+          throw new UserError(
+            `One or more column indices exceed table ${args.tableId} column count ${table.columnCount}.`
+          );
+        }
+
+        const request = GDocsHelpers.buildTableColumnWidthRequest(
+          table.startIndex,
+          args.columnIndices,
+          args.widthPt,
+          args.tabId
+        );
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [request]);
+        return `Successfully updated width for ${args.columnIndices.length} column(s) in ${args.tableId}.`;
+      } catch (error: any) {
+        log.error(
+          `Error updating column widths for ${args.tableId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Failed to update table column width: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/docs/formatting/updateTableRowStyle.ts
+++ b/src/tools/docs/formatting/updateTableRowStyle.ts
@@ -1,0 +1,103 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../../clients.js';
+import { DocumentIdParameter } from '../../../types.js';
+import { getTableById } from '../structureHelpers.js';
+import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'updateTableRowStyle',
+    description:
+      'Applies row-level styling to a Google Docs table, including minimum row height and optional pinned header rows.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z.string().min(1).describe('The MCP table ID returned by listDocumentTables.'),
+      rowIndices: z
+        .array(z.number().int().min(0))
+        .min(1)
+        .describe('Zero-based row indices to style.'),
+      minRowHeightPt: z.number().min(0).optional().describe('Minimum row height in points.'),
+      preventOverflow: z
+        .boolean()
+        .optional()
+        .describe('Whether row content should avoid overflowing outside the row.'),
+      pinnedHeaderRowsCount: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Optional number of header rows to pin at the top of the table.'),
+      tabId: z.string().optional().describe('Optional target tab ID.'),
+    }).refine(
+      (data) =>
+        data.minRowHeightPt !== undefined ||
+        data.preventOverflow !== undefined ||
+        data.pinnedHeaderRowsCount !== undefined,
+      {
+        message: 'At least one row style option must be provided.',
+      }
+    ),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Updating table row style in ${args.tableId} for doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+        });
+
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) throw new UserError(`Table "${args.tableId}" not found in document.`);
+        if (table.startIndex == null) {
+          throw new UserError(`Table "${args.tableId}" does not expose a valid table start index.`);
+        }
+        if (args.rowIndices.some((index) => index >= table.rowCount)) {
+          throw new UserError(
+            `One or more row indices exceed table ${args.tableId} row count ${table.rowCount}.`
+          );
+        }
+
+        const requests = [];
+        const styleRequest = GDocsHelpers.buildTableRowStyleRequest(
+          table.startIndex,
+          args.rowIndices,
+          args.minRowHeightPt,
+          args.preventOverflow,
+          args.tabId
+        );
+        if (styleRequest) requests.push(styleRequest);
+
+        if (args.pinnedHeaderRowsCount !== undefined) {
+          requests.push(
+            GDocsHelpers.buildPinTableHeaderRowsRequest(
+              table.startIndex,
+              args.pinnedHeaderRowsCount,
+              args.tabId
+            )
+          );
+        }
+
+        if (requests.length === 0) {
+          throw new UserError('No row style requests were generated.');
+        }
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, requests);
+        return `Successfully updated row style for ${args.tableId}.`;
+      } catch (error: any) {
+        log.error(
+          `Error updating table row style for ${args.tableId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Failed to update table row style: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/docs/getTableStructure.ts
+++ b/src/tools/docs/getTableStructure.ts
@@ -1,0 +1,57 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import { getTableById } from './structureHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'getTableStructure',
+    description:
+      'Returns detailed structure for a table in a Google Document, including row/column counts and extracted cell text.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z
+        .string()
+        .min(1)
+        .describe('The MCP table ID returned by listDocumentTables, for example "table:body:0".'),
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab to inspect. If not specified, inspects the first tab or legacy document body.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Getting table structure for ${args.tableId} in ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(textRun(content)))))))))))',
+        });
+
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) {
+          throw new UserError(`Table "${args.tableId}" not found in document.`);
+        }
+
+        return JSON.stringify(table, null, 2);
+      } catch (error: any) {
+        log.error(
+          `Error getting table structure for ${args.tableId} in doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(`Failed to get table structure: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/index.ts
+++ b/src/tools/docs/index.ts
@@ -18,6 +18,17 @@ import { register as insertPageBreak } from './insertPageBreak.js';
 import { register as insertSectionBreak } from './insertSectionBreak.js';
 import { register as updateSectionStyle } from './updateSectionStyle.js';
 import { register as insertImage } from './insertImage.js';
+import { register as insertDateChip } from './insertDateChip.js';
+import { register as insertPerson } from './insertPerson.js';
+import { register as insertRichLink } from './insertRichLink.js';
+import { register as listSmartChips } from './listSmartChips.js';
+import { register as cloneTable } from './cloneTable.js';
+import { register as listDocumentTables } from './listDocumentTables.js';
+import { register as getTableStructure } from './getTableStructure.js';
+import { register as findSectionsByHeading } from './findSectionsByHeading.js';
+import { register as replaceTableRowData } from './replaceTableRowData.js';
+import { register as appendTableRows } from './appendTableRows.js';
+import { register as deleteTableRows } from './deleteTableRows.js';
 
 // Sub-domains
 import { registerCommentTools } from './comments/index.js';
@@ -42,6 +53,17 @@ export function registerDocsTools(server: FastMCP) {
   insertSectionBreak(server);
   updateSectionStyle(server);
   insertImage(server);
+  insertDateChip(server);
+  insertPerson(server);
+  insertRichLink(server);
+  listSmartChips(server);
+  cloneTable(server);
+  listDocumentTables(server);
+  getTableStructure(server);
+  findSectionsByHeading(server);
+  replaceTableRowData(server);
+  appendTableRows(server);
+  deleteTableRows(server);
 
   // Sub-domains
   registerFormattingTools(server);

--- a/src/tools/docs/insertDateChip.ts
+++ b/src/tools/docs/insertDateChip.ts
@@ -1,0 +1,109 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { docs_v1 } from 'googleapis';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+
+const DateFormatSchema = z.enum([
+  'DATE_FORMAT_UNSPECIFIED',
+  'DATE_FORMAT_MONTH_DAY_ABBREVIATED',
+  'DATE_FORMAT_MONTH_DAY_FULL',
+  'DATE_FORMAT_MONTH_DAY_YEAR_ABBREVIATED',
+  'DATE_FORMAT_ISO8601',
+]);
+
+const TimeFormatSchema = z.enum([
+  'TIME_FORMAT_UNSPECIFIED',
+  'TIME_FORMAT_DISABLED',
+  'TIME_FORMAT_HOUR_MINUTE',
+  'TIME_FORMAT_HOUR_MINUTE_TIMEZONE',
+]);
+
+function toGoogleTimestamp(input: string): string {
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    throw new UserError(`Invalid date/time value: "${input}"`);
+  }
+  return date.toISOString();
+}
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'insertDateChip',
+    description:
+      'Inserts a Google Docs date smart chip at a specific paragraph location. This creates a real date element, not plain text.',
+    parameters: DocumentIdParameter.extend({
+      index: z
+        .number()
+        .int()
+        .min(1)
+        .describe(
+          '1-based character index within an existing paragraph where the date chip should be inserted.'
+        ),
+      date: z
+        .string()
+        .min(1)
+        .describe(
+          'Date or date-time input parseable by JavaScript Date, e.g. "2026-05-07T15:30:00+09:00".'
+        ),
+      timeZoneId: z
+        .string()
+        .optional()
+        .describe('Optional CLDR/IANA time zone, e.g. "Asia/Tokyo".'),
+      locale: z.string().optional().describe('Optional locale, e.g. "ja" or "en".'),
+      dateFormat: DateFormatSchema.optional().describe('How the date portion should be displayed.'),
+      timeFormat: TimeFormatSchema.optional().describe('How the time portion should be displayed.'),
+      tabId: z.string().optional().describe('Optional target tab ID.'),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Inserting date chip into ${args.documentId} at index ${args.index}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        if (args.tabId) {
+          const docInfo = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields: 'tabs(tabProperties,documentTab)',
+          });
+          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
+          if (!targetTab) throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
+          if (!targetTab.documentTab) {
+            throw new UserError(
+              `Tab "${args.tabId}" does not have content (may not be a document tab).`
+            );
+          }
+        }
+
+        const location: Record<string, unknown> = { index: args.index };
+        if (args.tabId) location.tabId = args.tabId;
+
+        const request: docs_v1.Schema$Request = {
+          insertDate: {
+            location: location as docs_v1.Schema$Location,
+            dateElementProperties: {
+              timestamp: toGoogleTimestamp(args.date),
+              timeZoneId: args.timeZoneId,
+              locale: args.locale,
+              dateFormat: args.dateFormat,
+              timeFormat: args.timeFormat,
+            },
+          },
+        };
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [request]);
+        return `Successfully inserted a date chip at index ${args.index}${args.tabId ? ` in tab ${args.tabId}` : ''}.`;
+      } catch (error: any) {
+        log.error(
+          `Error inserting date chip into doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to insert date chip: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/insertPerson.ts
+++ b/src/tools/docs/insertPerson.ts
@@ -1,0 +1,75 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { docs_v1 } from 'googleapis';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'insertPerson',
+    description:
+      'Inserts a Google Docs person smart chip at a specific paragraph location using an email address.',
+    parameters: DocumentIdParameter.extend({
+      index: z
+        .number()
+        .int()
+        .min(1)
+        .describe(
+          '1-based character index within an existing paragraph where the person chip should be inserted.'
+        ),
+      email: z.string().email().describe('Email address linked to the person smart chip.'),
+      name: z
+        .string()
+        .optional()
+        .describe('Optional display name hint when Google Docs resolves the person mention.'),
+      tabId: z.string().optional().describe('Optional target tab ID.'),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Inserting person chip into ${args.documentId} at index ${args.index}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        if (args.tabId) {
+          const docInfo = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields: 'tabs(tabProperties,documentTab)',
+          });
+          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
+          if (!targetTab) throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
+          if (!targetTab.documentTab) {
+            throw new UserError(
+              `Tab "${args.tabId}" does not have content (may not be a document tab).`
+            );
+          }
+        }
+
+        const location: Record<string, unknown> = { index: args.index };
+        if (args.tabId) location.tabId = args.tabId;
+
+        const request: docs_v1.Schema$Request = {
+          insertPerson: {
+            location: location as docs_v1.Schema$Location,
+            personProperties: {
+              email: args.email,
+              name: args.name,
+            },
+          },
+        };
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [request]);
+        return `Successfully inserted a person chip at index ${args.index}${args.tabId ? ` in tab ${args.tabId}` : ''}.`;
+      } catch (error: any) {
+        log.error(
+          `Error inserting person chip into doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to insert person chip: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/insertRichLink.ts
+++ b/src/tools/docs/insertRichLink.ts
@@ -1,0 +1,95 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { docs_v1 } from 'googleapis';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+
+interface RichLinkProperties {
+  uri: string;
+  mimeType?: string;
+  title?: string;
+}
+
+interface RichLinkRequest extends docs_v1.Schema$Request {
+  insertRichLink: {
+    location: docs_v1.Schema$Location;
+    richLinkProperties: RichLinkProperties;
+  };
+}
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'insertRichLink',
+    description:
+      'Inserts a Google Docs rich link smart chip at a specific paragraph location. Use for Google resource links such as Drive files or Calendar events.',
+    parameters: DocumentIdParameter.extend({
+      index: z
+        .number()
+        .int()
+        .min(1)
+        .describe(
+          '1-based character index within an existing paragraph where the rich link should be inserted.'
+        ),
+      uri: z.string().url().describe('URI of the Google resource for the rich link smart chip.'),
+      mimeType: z
+        .string()
+        .optional()
+        .describe('Optional MIME type of the linked resource, if known.'),
+      title: z
+        .string()
+        .optional()
+        .describe(
+          'Optional title hint. Google Docs may still resolve and display the canonical resource title.'
+        ),
+      tabId: z.string().optional().describe('Optional target tab ID.'),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Inserting rich link into ${args.documentId} at index ${args.index}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        if (args.tabId) {
+          const docInfo = await docs.documents.get({
+            documentId: args.documentId,
+            includeTabsContent: true,
+            fields: 'tabs(tabProperties,documentTab)',
+          });
+          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
+          if (!targetTab) throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
+          if (!targetTab.documentTab) {
+            throw new UserError(
+              `Tab "${args.tabId}" does not have content (may not be a document tab).`
+            );
+          }
+        }
+
+        const location: Record<string, unknown> = { index: args.index };
+        if (args.tabId) location.tabId = args.tabId;
+
+        const request: RichLinkRequest = {
+          insertRichLink: {
+            location: location as docs_v1.Schema$Location,
+            richLinkProperties: {
+              uri: args.uri,
+              mimeType: args.mimeType,
+              title: args.title,
+            },
+          },
+        };
+
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [request]);
+        return `Successfully inserted a rich link at index ${args.index}${args.tabId ? ` in tab ${args.tabId}` : ''}.`;
+      } catch (error: any) {
+        log.error(
+          `Error inserting rich link into doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to insert rich link: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/listDocumentTables.ts
+++ b/src/tools/docs/listDocumentTables.ts
@@ -1,0 +1,54 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import { extractDocumentTables } from './structureHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'listDocumentTables',
+    description:
+      'Lists tables in a Google Document with stable MCP table IDs, ranges, and dimensions. Use this before table-specific editing tools.',
+    parameters: DocumentIdParameter.extend({
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab to inspect. If not specified, inspects the first tab or legacy document body.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Listing document tables for ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))))',
+        });
+
+        const tables = extractDocumentTables(res.data, args.tabId).map((table) => ({
+          tableId: table.tableId,
+          startIndex: table.startIndex,
+          endIndex: table.endIndex,
+          rowCount: table.rowCount,
+          columnCount: table.columnCount,
+        }));
+
+        return JSON.stringify({ tables }, null, 2);
+      } catch (error: any) {
+        log.error(`Error listing tables for doc ${args.documentId}: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(`Failed to list document tables: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/listSmartChips.ts
+++ b/src/tools/docs/listSmartChips.ts
@@ -1,0 +1,49 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import { extractSmartChips } from './smartChipHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'listSmartChips',
+    description:
+      'Lists smart chips in a Google Document, including date elements, person mentions, and rich links.',
+    parameters: DocumentIdParameter.extend({
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab to inspect. If not specified, inspects the first tab or legacy document body.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Listing smart chips for ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties))),table(tableRows(tableCells(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties))),table(tableRows(tableCells(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties)))))))))))',
+        });
+
+        const chips = extractSmartChips(res.data, args.tabId);
+        return JSON.stringify({ smartChips: chips }, null, 2);
+      } catch (error: any) {
+        log.error(
+          `Error listing smart chips for doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(`Failed to list smart chips: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/docs/replaceTableRowData.ts
+++ b/src/tools/docs/replaceTableRowData.ts
@@ -1,0 +1,74 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getDocsClient } from '../../clients.js';
+import { DocumentIdParameter } from '../../types.js';
+import { getTableById } from './structureHelpers.js';
+import { replaceTableRowData as replaceTableRowDataInternal } from './tableRowDataHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'replaceTableRowData',
+    description:
+      'Replaces the plain-text contents of a single row in an existing Google Docs table while preserving the table structure and formatting.',
+    parameters: DocumentIdParameter.extend({
+      tableId: z
+        .string()
+        .min(1)
+        .describe('The MCP table ID returned by listDocumentTables, for example "table:body:0".'),
+      rowIndex: z.number().int().min(0).describe('Zero-based row index to replace.'),
+      values: z
+        .array(z.string())
+        .max(50)
+        .describe('Plain-text values to place into the row cells from left to right.'),
+      tabId: z
+        .string()
+        .optional()
+        .describe(
+          'The ID of the specific tab containing the table. If not specified, uses the first tab or legacy document body.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const docs = await getDocsClient();
+      log.info(
+        `Replacing row ${args.rowIndex} in ${args.tableId} for doc ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`
+      );
+
+      try {
+        const res = await docs.documents.get({
+          documentId: args.documentId,
+          includeTabsContent: true,
+          fields:
+            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+        });
+
+        const table = getTableById(res.data, args.tableId, args.tabId);
+        if (!table) {
+          throw new UserError(`Table "${args.tableId}" not found in document.`);
+        }
+
+        await replaceTableRowDataInternal(
+          docs,
+          args.documentId,
+          table,
+          args.rowIndex,
+          args.values,
+          args.tabId
+        );
+
+        return `Successfully replaced row ${args.rowIndex} in table ${args.tableId}.`;
+      } catch (error: any) {
+        log.error(
+          `Error replacing row ${args.rowIndex} in ${args.tableId} for doc ${args.documentId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
+        if (error.code === 403)
+          throw new UserError(`Permission denied for document (ID: ${args.documentId}).`);
+        throw new UserError(
+          `Failed to replace table row data: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/docs/smartChipHelpers.test.ts
+++ b/src/tools/docs/smartChipHelpers.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { extractSmartChips } from './smartChipHelpers.js';
+
+const mockDocument = {
+  body: {
+    content: [
+      {
+        startIndex: 1,
+        endIndex: 35,
+        paragraph: {
+          elements: [
+            {
+              startIndex: 1,
+              endIndex: 2,
+              dateElement: {
+                dateId: 'date-1',
+                dateElementProperties: {
+                  displayText: '2026/05/07 15:30',
+                  timestamp: '2026-05-07T06:30:00Z',
+                  timeZoneId: 'Asia/Tokyo',
+                },
+              },
+            },
+            {
+              startIndex: 2,
+              endIndex: 3,
+              richLink: {
+                richLinkId: 'link-1',
+                richLinkProperties: {
+                  title: 'Planning Template',
+                  uri: 'https://docs.google.com/document/d/example/edit',
+                },
+              },
+            },
+            {
+              startIndex: 3,
+              endIndex: 4,
+              person: {
+                personId: 'person-1',
+                personProperties: {
+                  name: 'Nguyen Hien',
+                  email: 'hien@example.com',
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        startIndex: 35,
+        endIndex: 80,
+        table: {
+          tableRows: [
+            {
+              tableCells: [
+                {
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [
+                          {
+                            startIndex: 40,
+                            endIndex: 41,
+                            dateElement: {
+                              dateId: 'date-2',
+                              dateElementProperties: {
+                                displayText: '2026/05/08',
+                                timestamp: '2026-05-07T15:00:00Z',
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  },
+  tabs: [
+    {
+      tabProperties: {
+        tabId: 'tab-1',
+        title: 'Tab 1',
+      },
+      documentTab: {
+        body: {
+          content: [
+            {
+              startIndex: 1,
+              endIndex: 10,
+              paragraph: {
+                elements: [
+                  {
+                    startIndex: 1,
+                    endIndex: 2,
+                    person: {
+                      personId: 'person-tab',
+                      personProperties: {
+                        email: 'tab@example.com',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+} as any;
+
+describe('extractSmartChips', () => {
+  it('extracts date, rich link, and person chips from body content and tables', () => {
+    const chips = extractSmartChips(mockDocument);
+
+    expect(chips).toEqual([
+      {
+        type: 'date',
+        startIndex: 1,
+        endIndex: 2,
+        text: '2026/05/07 15:30',
+        properties: {
+          dateId: 'date-1',
+          displayText: '2026/05/07 15:30',
+          timestamp: '2026-05-07T06:30:00Z',
+          timeZoneId: 'Asia/Tokyo',
+        },
+      },
+      {
+        type: 'richLink',
+        startIndex: 2,
+        endIndex: 3,
+        text: 'Planning Template',
+        properties: {
+          richLinkId: 'link-1',
+          title: 'Planning Template',
+          uri: 'https://docs.google.com/document/d/example/edit',
+        },
+      },
+      {
+        type: 'person',
+        startIndex: 3,
+        endIndex: 4,
+        text: 'Nguyen Hien',
+        properties: {
+          personId: 'person-1',
+          name: 'Nguyen Hien',
+          email: 'hien@example.com',
+        },
+      },
+      {
+        type: 'date',
+        startIndex: 40,
+        endIndex: 41,
+        text: '2026/05/08',
+        properties: {
+          dateId: 'date-2',
+          displayText: '2026/05/08',
+          timestamp: '2026-05-07T15:00:00Z',
+        },
+      },
+    ]);
+  });
+
+  it('can scope extraction to a specific tab', () => {
+    const chips = extractSmartChips(mockDocument, 'tab-1');
+
+    expect(chips).toEqual([
+      {
+        type: 'person',
+        startIndex: 1,
+        endIndex: 2,
+        text: 'tab@example.com',
+        properties: {
+          personId: 'person-tab',
+          email: 'tab@example.com',
+        },
+      },
+    ]);
+  });
+});

--- a/src/tools/docs/smartChipHelpers.ts
+++ b/src/tools/docs/smartChipHelpers.ts
@@ -1,0 +1,94 @@
+import { docs_v1 } from 'googleapis';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+
+export interface ExtractedSmartChip {
+  type: 'date' | 'richLink' | 'person';
+  startIndex: number | null;
+  endIndex: number | null;
+  text?: string | null;
+  properties: Record<string, unknown>;
+}
+
+function getContentSource(
+  doc: docs_v1.Schema$Document,
+  tabId?: string
+): docs_v1.Schema$StructuralElement[] {
+  if (tabId) {
+    const targetTab = GDocsHelpers.findTabById(doc, tabId);
+    if (!targetTab?.documentTab?.body?.content) return [];
+    return targetTab.documentTab.body.content;
+  }
+
+  if (doc.body?.content) return doc.body.content;
+  if (doc.tabs?.[0]?.documentTab?.body?.content) return doc.tabs[0].documentTab.body.content;
+  return [];
+}
+
+function visitContent(
+  content: docs_v1.Schema$StructuralElement[],
+  out: ExtractedSmartChip[]
+): void {
+  for (const element of content) {
+    for (const paragraphElement of element.paragraph?.elements ?? []) {
+      if (paragraphElement.dateElement) {
+        out.push({
+          type: 'date',
+          startIndex: paragraphElement.startIndex ?? null,
+          endIndex: paragraphElement.endIndex ?? null,
+          text: paragraphElement.dateElement.dateElementProperties?.displayText ?? null,
+          properties: {
+            dateId: paragraphElement.dateElement.dateId ?? null,
+            ...paragraphElement.dateElement.dateElementProperties,
+          },
+        });
+      }
+
+      if (paragraphElement.richLink) {
+        out.push({
+          type: 'richLink',
+          startIndex: paragraphElement.startIndex ?? null,
+          endIndex: paragraphElement.endIndex ?? null,
+          text: paragraphElement.richLink.richLinkProperties?.title ?? null,
+          properties: {
+            richLinkId: paragraphElement.richLink.richLinkId ?? null,
+            ...paragraphElement.richLink.richLinkProperties,
+          },
+        });
+      }
+
+      if (paragraphElement.person) {
+        out.push({
+          type: 'person',
+          startIndex: paragraphElement.startIndex ?? null,
+          endIndex: paragraphElement.endIndex ?? null,
+          text:
+            paragraphElement.person.personProperties?.name ??
+            paragraphElement.person.personProperties?.email ??
+            null,
+          properties: {
+            personId: paragraphElement.person.personId ?? null,
+            ...paragraphElement.person.personProperties,
+          },
+        });
+      }
+    }
+
+    if (element.table?.tableRows) {
+      for (const row of element.table.tableRows) {
+        for (const cell of row.tableCells ?? []) {
+          visitContent(cell.content ?? [], out);
+        }
+      }
+    }
+  }
+}
+
+export function extractSmartChips(
+  doc: docs_v1.Schema$Document,
+  tabId?: string
+): ExtractedSmartChip[] {
+  const content = getContentSource(doc, tabId);
+  const chips: ExtractedSmartChip[] = [];
+  visitContent(content, chips);
+  return chips;
+}

--- a/src/tools/docs/structureHelpers.test.ts
+++ b/src/tools/docs/structureHelpers.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { extractDocumentTables, findHeadings, getTableById } from './structureHelpers.js';
+
+const mockDocument = {
+  body: {
+    content: [
+      {
+        startIndex: 1,
+        endIndex: 25,
+        paragraph: {
+          paragraphStyle: { namedStyleType: 'HEADING_2' },
+          elements: [{ textRun: { content: '今回のスプリントのタスク\n' } }],
+        },
+      },
+      {
+        startIndex: 25,
+        endIndex: 120,
+        table: {
+          tableRows: [
+            {
+              tableCells: [
+                {
+                  startIndex: 30,
+                  endIndex: 40,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [{ textRun: { content: 'No.\n' } }],
+                      },
+                    },
+                  ],
+                },
+                {
+                  startIndex: 40,
+                  endIndex: 60,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [{ textRun: { content: '課題名\n' } }],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              tableCells: [
+                {
+                  startIndex: 60,
+                  endIndex: 78,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [{ textRun: { content: '1\n' } }],
+                      },
+                    },
+                  ],
+                },
+                {
+                  startIndex: 78,
+                  endIndex: 118,
+                  content: [
+                    {
+                      paragraph: {
+                        elements: [{ textRun: { content: 'SHIN-2870 調査\n' } }],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        startIndex: 120,
+        endIndex: 145,
+        paragraph: {
+          paragraphStyle: { namedStyleType: 'HEADING_2' },
+          elements: [{ textRun: { content: '5. TDAからTAPへの確認事項\n' } }],
+        },
+      },
+    ],
+  },
+} as any;
+
+describe('structureHelpers', () => {
+  it('extracts tables with dimensions and cell text', () => {
+    const tables = extractDocumentTables(mockDocument);
+
+    expect(tables).toHaveLength(1);
+    expect(tables[0]).toMatchObject({
+      tableId: 'table:body:0',
+      rowCount: 2,
+      columnCount: 2,
+      startIndex: 25,
+      endIndex: 120,
+    });
+    expect(tables[0].cells).toEqual([
+      {
+        rowIndex: 0,
+        columnIndex: 0,
+        startIndex: 30,
+        endIndex: 40,
+        contentStartIndex: null,
+        contentEndIndex: null,
+        text: 'No.',
+      },
+      {
+        rowIndex: 0,
+        columnIndex: 1,
+        startIndex: 40,
+        endIndex: 60,
+        contentStartIndex: null,
+        contentEndIndex: null,
+        text: '課題名',
+      },
+      {
+        rowIndex: 1,
+        columnIndex: 0,
+        startIndex: 60,
+        endIndex: 78,
+        contentStartIndex: null,
+        contentEndIndex: null,
+        text: '1',
+      },
+      {
+        rowIndex: 1,
+        columnIndex: 1,
+        startIndex: 78,
+        endIndex: 118,
+        contentStartIndex: null,
+        contentEndIndex: null,
+        text: 'SHIN-2870 調査',
+      },
+    ]);
+  });
+
+  it('finds a table by its MCP table ID', () => {
+    const table = getTableById(mockDocument, 'table:body:0');
+
+    expect(table?.tableId).toBe('table:body:0');
+    expect(getTableById(mockDocument, 'table:body:999')).toBeNull();
+  });
+
+  it('finds heading sections and the next table following the heading', () => {
+    const sections = findHeadings(mockDocument, [
+      '今回のスプリントのタスク',
+      '5. TDAからTAPへの確認事項',
+    ]);
+
+    expect(sections).toEqual([
+      {
+        headingText: '今回のスプリントのタスク',
+        headingLevel: 'HEADING_2',
+        startIndex: 1,
+        endIndex: 25,
+        tableIdFollowing: 'table:body:0',
+      },
+      {
+        headingText: '5. TDAからTAPへの確認事項',
+        headingLevel: 'HEADING_2',
+        startIndex: 120,
+        endIndex: 145,
+        tableIdFollowing: undefined,
+      },
+    ]);
+  });
+});

--- a/src/tools/docs/structureHelpers.ts
+++ b/src/tools/docs/structureHelpers.ts
@@ -1,0 +1,397 @@
+import { docs_v1 } from 'googleapis';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+
+export interface ExtractedTableCell {
+  rowIndex: number;
+  columnIndex: number;
+  startIndex: number | null;
+  endIndex: number | null;
+  contentStartIndex: number | null;
+  contentEndIndex: number | null;
+  text: string;
+}
+
+export interface ExtractedTable {
+  tableId: string;
+  ordinal: number;
+  startIndex: number | null;
+  endIndex: number | null;
+  rowCount: number;
+  columnCount: number;
+  cells: ExtractedTableCell[];
+}
+
+export interface ExtractedHeading {
+  headingText: string;
+  headingLevel: string;
+  startIndex: number | null;
+  endIndex: number | null;
+  tableIdFollowing?: string;
+}
+
+export interface ExtractedTableColumnStyle {
+  columnIndex: number;
+  widthPt?: number;
+  widthType?: string | null;
+}
+
+export interface ExtractedTableRowStyle {
+  rowIndex: number;
+  minRowHeightPt?: number;
+  preventOverflow?: boolean;
+  tableHeader?: boolean;
+}
+
+export interface ExtractedTableCellStyle {
+  rowIndex: number;
+  columnIndex: number;
+  backgroundColor?: docs_v1.Schema$RgbColor;
+  contentAlignment?: 'CONTENT_ALIGNMENT_UNSPECIFIED' | 'LEFT' | 'CENTER' | 'RIGHT' | null;
+  paddingTopPt?: number;
+  paddingBottomPt?: number;
+  paddingLeftPt?: number;
+  paddingRightPt?: number;
+  borderTop?: docs_v1.Schema$TableCellBorder;
+  borderBottom?: docs_v1.Schema$TableCellBorder;
+  borderLeft?: docs_v1.Schema$TableCellBorder;
+  borderRight?: docs_v1.Schema$TableCellBorder;
+  hasBoldText?: boolean;
+}
+
+export interface ExtractedTableSnapshot {
+  tableId: string;
+  startIndex: number | null;
+  endIndex: number | null;
+  rowCount: number;
+  columnCount: number;
+  data: string[][];
+  columnStyles: ExtractedTableColumnStyle[];
+  rowStyles: ExtractedTableRowStyle[];
+  cellStyles: ExtractedTableCellStyle[];
+  pinnedHeaderRowsCount: number;
+}
+
+function getContentSource(
+  doc: docs_v1.Schema$Document,
+  tabId?: string
+): docs_v1.Schema$StructuralElement[] {
+  if (tabId) {
+    const targetTab = GDocsHelpers.findTabById(doc, tabId);
+    if (!targetTab?.documentTab?.body?.content) {
+      return [];
+    }
+    return targetTab.documentTab.body.content;
+  }
+
+  if (doc.body?.content) {
+    return doc.body.content;
+  }
+
+  if (doc.tabs?.[0]?.documentTab?.body?.content) {
+    return doc.tabs[0].documentTab.body.content;
+  }
+
+  return [];
+}
+
+function extractParagraphText(paragraph?: docs_v1.Schema$Paragraph): string {
+  return (
+    paragraph?.elements
+      ?.map((element) => element.textRun?.content ?? '')
+      .join('')
+      .replace(/\n+$/g, '') ?? ''
+  );
+}
+
+function extractCellText(content: docs_v1.Schema$StructuralElement[] = []): string {
+  const parts: string[] = [];
+
+  for (const element of content) {
+    if (element.paragraph) {
+      const text = extractParagraphText(element.paragraph);
+      if (text) parts.push(text);
+    }
+
+    if (element.table?.tableRows) {
+      for (const row of element.table.tableRows) {
+        for (const cell of row.tableCells ?? []) {
+          const text = extractCellText(cell.content ?? []);
+          if (text) parts.push(text);
+        }
+      }
+    }
+  }
+
+  return parts.join('\n').trim();
+}
+
+function extractCellContentRange(content: docs_v1.Schema$StructuralElement[] = []): {
+  contentStartIndex: number | null;
+  contentEndIndex: number | null;
+} {
+  let minStart: number | null = null;
+  let maxEnd: number | null = null;
+
+  const visitContent = (elements: docs_v1.Schema$StructuralElement[]) => {
+    for (const element of elements) {
+      for (const paragraphElement of element.paragraph?.elements ?? []) {
+        const startIndex = paragraphElement.startIndex;
+        if (typeof startIndex === 'number') {
+          minStart = minStart === null ? startIndex : Math.min(minStart, startIndex);
+        }
+        const endIndex = paragraphElement.endIndex;
+        if (typeof endIndex === 'number') {
+          maxEnd = maxEnd === null ? endIndex : Math.max(maxEnd, endIndex);
+        }
+      }
+
+      if (element.table?.tableRows) {
+        for (const row of element.table.tableRows) {
+          for (const cell of row.tableCells ?? []) {
+            visitContent(cell.content ?? []);
+          }
+        }
+      }
+    }
+  };
+
+  visitContent(content);
+
+  return {
+    contentStartIndex: minStart,
+    contentEndIndex: maxEnd,
+  };
+}
+
+function dimensionToPt(dimension?: docs_v1.Schema$Dimension): number | undefined {
+  if (!dimension?.magnitude || dimension.unit !== 'PT') return undefined;
+  return dimension.magnitude;
+}
+
+function normalizeCellStyle(
+  rowIndex: number,
+  columnIndex: number,
+  cell: docs_v1.Schema$TableCell
+): ExtractedTableCellStyle | null {
+  const style = cell.tableCellStyle;
+  const firstParagraphHasBoldText = (cell.content ?? []).some((element) =>
+    (element.paragraph?.elements ?? []).some(
+      (paragraphElement) => paragraphElement.textRun?.textStyle?.bold
+    )
+  );
+
+  if (!style && !firstParagraphHasBoldText) return null;
+
+  const contentAlignment =
+    style?.contentAlignment === 'LEFT' ||
+    style?.contentAlignment === 'CENTER' ||
+    style?.contentAlignment === 'RIGHT' ||
+    style?.contentAlignment === 'CONTENT_ALIGNMENT_UNSPECIFIED'
+      ? style.contentAlignment
+      : null;
+
+  return {
+    rowIndex,
+    columnIndex,
+    backgroundColor: style?.backgroundColor?.color?.rgbColor ?? undefined,
+    contentAlignment,
+    paddingTopPt: dimensionToPt(style?.paddingTop),
+    paddingBottomPt: dimensionToPt(style?.paddingBottom),
+    paddingLeftPt: dimensionToPt(style?.paddingLeft),
+    paddingRightPt: dimensionToPt(style?.paddingRight),
+    borderTop: style?.borderTop ?? undefined,
+    borderBottom: style?.borderBottom ?? undefined,
+    borderLeft: style?.borderLeft ?? undefined,
+    borderRight: style?.borderRight ?? undefined,
+    hasBoldText: firstParagraphHasBoldText || undefined,
+  };
+}
+
+export function extractDocumentTables(
+  doc: docs_v1.Schema$Document,
+  tabId?: string
+): ExtractedTable[] {
+  const content = getContentSource(doc, tabId);
+  const tables: ExtractedTable[] = [];
+  const tabKey = tabId ?? 'body';
+
+  for (const element of content) {
+    if (!element.table?.tableRows) continue;
+
+    const ordinal = tables.length;
+    const cells: ExtractedTableCell[] = [];
+    let columnCount = 0;
+
+    element.table.tableRows.forEach((row, rowIndex) => {
+      const rowCells = row.tableCells ?? [];
+      columnCount = Math.max(columnCount, rowCells.length);
+
+      rowCells.forEach((cell, columnIndex) => {
+        const { contentStartIndex, contentEndIndex } = extractCellContentRange(cell.content ?? []);
+        cells.push({
+          rowIndex,
+          columnIndex,
+          startIndex: cell.startIndex ?? null,
+          endIndex: cell.endIndex ?? null,
+          contentStartIndex,
+          contentEndIndex,
+          text: extractCellText(cell.content ?? []),
+        });
+      });
+    });
+
+    tables.push({
+      tableId: `table:${tabKey}:${ordinal}`,
+      ordinal,
+      startIndex: element.startIndex ?? null,
+      endIndex: element.endIndex ?? null,
+      rowCount: element.table.tableRows.length,
+      columnCount,
+      cells,
+    });
+  }
+
+  return tables;
+}
+
+export function getTableById(
+  doc: docs_v1.Schema$Document,
+  tableId: string,
+  tabId?: string
+): ExtractedTable | null {
+  return extractDocumentTables(doc, tabId).find((table) => table.tableId === tableId) ?? null;
+}
+
+export function findTableNearestStartIndex(
+  doc: docs_v1.Schema$Document,
+  insertionIndex: number,
+  tabId?: string
+): ExtractedTable | null {
+  const tables = extractDocumentTables(doc, tabId).filter(
+    (table) => typeof table.startIndex === 'number' && table.startIndex >= insertionIndex
+  );
+  if (tables.length === 0) return null;
+
+  return tables.sort((a, b) => a.startIndex! - b.startIndex!)[0] ?? null;
+}
+
+export function extractTableSnapshot(
+  doc: docs_v1.Schema$Document,
+  tableId: string,
+  tabId?: string
+): ExtractedTableSnapshot | null {
+  const content = getContentSource(doc, tabId);
+  const tabKey = tabId ?? 'body';
+  let ordinal = 0;
+
+  for (const element of content) {
+    if (!element.table?.tableRows) continue;
+
+    const currentTableId = `table:${tabKey}:${ordinal}`;
+    ordinal++;
+    if (currentTableId !== tableId) continue;
+
+    const data: string[][] = [];
+    const rowStyles: ExtractedTableRowStyle[] = [];
+    const cellStyles: ExtractedTableCellStyle[] = [];
+    let pinnedHeaderRowsCount = 0;
+
+    element.table.tableRows.forEach((row, rowIndex) => {
+      const rowData: string[] = [];
+      const rowStyle = row.tableRowStyle;
+
+      if (rowStyle) {
+        rowStyles.push({
+          rowIndex,
+          minRowHeightPt: dimensionToPt(rowStyle.minRowHeight),
+          preventOverflow: rowStyle.preventOverflow ?? undefined,
+          tableHeader: rowStyle.tableHeader ?? undefined,
+        });
+      }
+
+      if ((rowStyle?.tableHeader ?? false) && pinnedHeaderRowsCount === rowIndex) {
+        pinnedHeaderRowsCount++;
+      }
+
+      (row.tableCells ?? []).forEach((cell, columnIndex) => {
+        rowData.push(extractCellText(cell.content ?? []));
+        const cellStyle = normalizeCellStyle(rowIndex, columnIndex, cell);
+        if (cellStyle) cellStyles.push(cellStyle);
+      });
+
+      data.push(rowData);
+    });
+
+    const columnStyles: ExtractedTableColumnStyle[] =
+      element.table.tableStyle?.tableColumnProperties?.map((column, columnIndex) => ({
+        columnIndex,
+        widthPt: dimensionToPt(column.width),
+        widthType: column.widthType,
+      })) ?? [];
+
+    return {
+      tableId: currentTableId,
+      startIndex: element.startIndex ?? null,
+      endIndex: element.endIndex ?? null,
+      rowCount: element.table.rows ?? data.length,
+      columnCount: element.table.columns ?? Math.max(...data.map((row) => row.length), 0),
+      data,
+      columnStyles,
+      rowStyles,
+      cellStyles,
+      pinnedHeaderRowsCount,
+    };
+  }
+
+  return null;
+}
+
+export function findHeadings(
+  doc: docs_v1.Schema$Document,
+  headings: string[],
+  tabId?: string
+): ExtractedHeading[] {
+  const content = getContentSource(doc, tabId);
+  const normalizedTargets = new Set(headings.map((heading) => heading.trim()));
+  const tables = extractDocumentTables(doc, tabId);
+  const results: ExtractedHeading[] = [];
+  let seenTables = 0;
+
+  for (let index = 0; index < content.length; index++) {
+    const element = content[index];
+
+    if (element.table?.tableRows) {
+      seenTables++;
+      continue;
+    }
+
+    const namedStyleType = element.paragraph?.paragraphStyle?.namedStyleType;
+    if (!namedStyleType || !namedStyleType.startsWith('HEADING_')) continue;
+
+    const headingText = extractParagraphText(element.paragraph).trim();
+    if (!normalizedTargets.has(headingText)) continue;
+
+    let tableIdFollowing: string | undefined;
+    for (let nextIndex = index + 1; nextIndex < content.length; nextIndex++) {
+      const nextElement = content[nextIndex];
+      if (nextElement.table?.tableRows) {
+        tableIdFollowing = tables[seenTables]?.tableId;
+        break;
+      }
+      if (nextElement.paragraph) {
+        const nextStyle = nextElement.paragraph.paragraphStyle?.namedStyleType;
+        if (nextStyle?.startsWith('HEADING_')) break;
+      }
+    }
+
+    results.push({
+      headingText,
+      headingLevel: namedStyleType,
+      startIndex: element.startIndex ?? null,
+      endIndex: element.endIndex ?? null,
+      tableIdFollowing,
+    });
+  }
+
+  return results;
+}

--- a/src/tools/docs/tableRowDataHelpers.test.ts
+++ b/src/tools/docs/tableRowDataHelpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildReplaceTableCellContentRequests } from './tableRowDataHelpers.js';
+import {
+  buildReplaceTableCellContentRequests,
+  buildReplaceTableRowRequests,
+} from './tableRowDataHelpers.js';
 
 describe('buildReplaceTableCellContentRequests', () => {
   it('builds delete + insert requests for a populated cell', () => {
@@ -63,5 +66,48 @@ describe('buildReplaceTableCellContentRequests', () => {
       startIndex: 71,
       endIndex: 74,
     });
+  });
+
+  it('builds one atomic request list for the whole row in reverse column order', () => {
+    const requests = buildReplaceTableRowRequests(
+      {
+        tableId: 'table:body:1',
+        ordinal: 1,
+        startIndex: 100,
+        endIndex: 140,
+        rowCount: 2,
+        columnCount: 2,
+        cells: [
+          {
+            rowIndex: 1,
+            columnIndex: 0,
+            startIndex: 101,
+            endIndex: 110,
+            contentStartIndex: 102,
+            contentEndIndex: 105,
+            text: 'A',
+          },
+          {
+            rowIndex: 1,
+            columnIndex: 1,
+            startIndex: 110,
+            endIndex: 120,
+            contentStartIndex: 111,
+            contentEndIndex: 114,
+            text: 'B',
+          },
+        ],
+      },
+      1,
+      ['left', 'right']
+    );
+
+    expect(requests).toHaveLength(4);
+    expect(requests[0].deleteContentRange?.range).toEqual({ startIndex: 111, endIndex: 113 });
+    expect(requests[1].insertText?.location?.index).toBe(111);
+    expect(requests[1].insertText?.text).toBe('right');
+    expect(requests[2].deleteContentRange?.range).toEqual({ startIndex: 102, endIndex: 104 });
+    expect(requests[3].insertText?.location?.index).toBe(102);
+    expect(requests[3].insertText?.text).toBe('left');
   });
 });

--- a/src/tools/docs/tableRowDataHelpers.test.ts
+++ b/src/tools/docs/tableRowDataHelpers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildReplaceTableCellContentRequests } from './tableRowDataHelpers.js';
+
+describe('buildReplaceTableCellContentRequests', () => {
+  it('builds delete + insert requests for a populated cell', () => {
+    const requests = buildReplaceTableCellContentRequests(
+      {
+        rowIndex: 1,
+        columnIndex: 2,
+        startIndex: 100,
+        endIndex: 120,
+        contentStartIndex: 101,
+        contentEndIndex: 110,
+        text: 'Old value',
+      },
+      'New value'
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0].deleteContentRange?.range).toEqual({
+      startIndex: 101,
+      endIndex: 109,
+    });
+    expect(requests[1].insertText?.location?.index).toBe(101);
+    expect(requests[1].insertText?.text).toBe('New value');
+  });
+
+  it('builds insert-only requests for an empty cell with a writable content index', () => {
+    const requests = buildReplaceTableCellContentRequests(
+      {
+        rowIndex: 0,
+        columnIndex: 0,
+        startIndex: 50,
+        endIndex: 60,
+        contentStartIndex: 51,
+        contentEndIndex: 52,
+        text: '',
+      },
+      'Value'
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].insertText?.location?.index).toBe(51);
+    expect(requests[0].insertText?.text).toBe('Value');
+  });
+
+  it('builds delete-only requests when replacing with an empty string', () => {
+    const requests = buildReplaceTableCellContentRequests(
+      {
+        rowIndex: 0,
+        columnIndex: 1,
+        startIndex: 70,
+        endIndex: 90,
+        contentStartIndex: 71,
+        contentEndIndex: 75,
+        text: 'ABC',
+      },
+      ''
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].deleteContentRange?.range).toEqual({
+      startIndex: 71,
+      endIndex: 74,
+    });
+  });
+});

--- a/src/tools/docs/tableRowDataHelpers.ts
+++ b/src/tools/docs/tableRowDataHelpers.ts
@@ -1,0 +1,82 @@
+import { docs_v1 } from 'googleapis';
+import { UserError } from 'fastmcp';
+import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { ExtractedTable } from './structureHelpers.js';
+
+type Docs = docs_v1.Docs;
+
+export function buildReplaceTableCellContentRequests(
+  cell: ExtractedTable['cells'][number],
+  nextValue: string,
+  tabId?: string
+): docs_v1.Schema$Request[] {
+  const requests: docs_v1.Schema$Request[] = [];
+
+  const insertionIndex = cell.contentStartIndex ?? cell.startIndex;
+  if (insertionIndex == null) {
+    throw new UserError(
+      `Cell [row=${cell.rowIndex}, col=${cell.columnIndex}] does not have a writable insertion index.`
+    );
+  }
+
+  if (
+    cell.text &&
+    cell.contentStartIndex !== null &&
+    cell.contentEndIndex !== null &&
+    cell.contentEndIndex - 1 > cell.contentStartIndex
+  ) {
+    const range: Record<string, unknown> = {
+      startIndex: cell.contentStartIndex,
+      endIndex: cell.contentEndIndex - 1,
+    };
+    if (tabId) range.tabId = tabId;
+    requests.push({
+      deleteContentRange: { range: range as docs_v1.Schema$Range },
+    });
+  }
+
+  if (nextValue) {
+    const location: Record<string, unknown> = { index: insertionIndex };
+    if (tabId) location.tabId = tabId;
+    requests.push({
+      insertText: {
+        location: location as docs_v1.Schema$Location,
+        text: nextValue,
+      },
+    });
+  }
+
+  return requests;
+}
+
+export async function replaceTableRowData(
+  docs: Docs,
+  documentId: string,
+  table: ExtractedTable,
+  rowIndex: number,
+  values: string[],
+  tabId?: string
+): Promise<void> {
+  if (rowIndex < 0 || rowIndex >= table.rowCount) {
+    throw new UserError(
+      `Row index ${rowIndex} is out of bounds for table ${table.tableId} with ${table.rowCount} rows.`
+    );
+  }
+
+  const rowCells = table.cells
+    .filter((cell) => cell.rowIndex === rowIndex)
+    .sort((a, b) => b.columnIndex - a.columnIndex);
+
+  if (values.length > table.columnCount) {
+    throw new UserError(
+      `Received ${values.length} values for table ${table.tableId}, but the table only has ${table.columnCount} columns.`
+    );
+  }
+
+  for (const cell of rowCells) {
+    const nextValue = values[cell.columnIndex] ?? '';
+    const requests = buildReplaceTableCellContentRequests(cell, nextValue, tabId);
+    if (requests.length === 0) continue;
+    await GDocsHelpers.executeBatchUpdate(docs, documentId, requests);
+  }
+}

--- a/src/tools/docs/tableRowDataHelpers.ts
+++ b/src/tools/docs/tableRowDataHelpers.ts
@@ -70,7 +70,9 @@ export function buildReplaceTableRowRequests(
   return table.cells
     .filter((cell) => cell.rowIndex === rowIndex)
     .sort((a, b) => b.columnIndex - a.columnIndex)
-    .flatMap((cell) => buildReplaceTableCellContentRequests(cell, values[cell.columnIndex] ?? '', tabId));
+    .flatMap((cell) =>
+      buildReplaceTableCellContentRequests(cell, values[cell.columnIndex] ?? '', tabId)
+    );
 }
 
 export async function replaceTableRowData(

--- a/src/tools/docs/tableRowDataHelpers.ts
+++ b/src/tools/docs/tableRowDataHelpers.ts
@@ -49,6 +49,30 @@ export function buildReplaceTableCellContentRequests(
   return requests;
 }
 
+export function buildReplaceTableRowRequests(
+  table: ExtractedTable,
+  rowIndex: number,
+  values: string[],
+  tabId?: string
+): docs_v1.Schema$Request[] {
+  if (rowIndex < 0 || rowIndex >= table.rowCount) {
+    throw new UserError(
+      `Row index ${rowIndex} is out of bounds for table ${table.tableId} with ${table.rowCount} rows.`
+    );
+  }
+
+  if (values.length > table.columnCount) {
+    throw new UserError(
+      `Received ${values.length} values for table ${table.tableId}, but the table only has ${table.columnCount} columns.`
+    );
+  }
+
+  return table.cells
+    .filter((cell) => cell.rowIndex === rowIndex)
+    .sort((a, b) => b.columnIndex - a.columnIndex)
+    .flatMap((cell) => buildReplaceTableCellContentRequests(cell, values[cell.columnIndex] ?? '', tabId));
+}
+
 export async function replaceTableRowData(
   docs: Docs,
   documentId: string,
@@ -57,26 +81,7 @@ export async function replaceTableRowData(
   values: string[],
   tabId?: string
 ): Promise<void> {
-  if (rowIndex < 0 || rowIndex >= table.rowCount) {
-    throw new UserError(
-      `Row index ${rowIndex} is out of bounds for table ${table.tableId} with ${table.rowCount} rows.`
-    );
-  }
-
-  const rowCells = table.cells
-    .filter((cell) => cell.rowIndex === rowIndex)
-    .sort((a, b) => b.columnIndex - a.columnIndex);
-
-  if (values.length > table.columnCount) {
-    throw new UserError(
-      `Received ${values.length} values for table ${table.tableId}, but the table only has ${table.columnCount} columns.`
-    );
-  }
-
-  for (const cell of rowCells) {
-    const nextValue = values[cell.columnIndex] ?? '';
-    const requests = buildReplaceTableCellContentRequests(cell, nextValue, tabId);
-    if (requests.length === 0) continue;
-    await GDocsHelpers.executeBatchUpdate(docs, documentId, requests);
-  }
+  const requests = buildReplaceTableRowRequests(table, rowIndex, values, tabId);
+  if (requests.length === 0) return;
+  await GDocsHelpers.executeBatchUpdate(docs, documentId, requests);
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,9 @@ import { registerUtilsTools } from './utils/index.js';
 import { registerGmailTools } from './gmail/index.js';
 import { registerCalendarTools } from './calendar/index.js';
 
+/**
+ * Registers all tools with the FastMCP server.
+ */
 export function registerAllTools(server: FastMCP) {
   registerDocsTools(server);
   registerDriveTools(server);


### PR DESCRIPTION
## What this adds
- Docs tools for planning-style table discovery and safe targeting
- row mutation helpers to replace, append, and delete table rows without replacing the whole document
- table formatting tools for cell style, borders, widths, and row styling
- smart chip tools for date, person, and rich-link content
- table cloning plus an opt-in live integration test to verify formatting preservation against the real Google Docs API

## Why
The existing markdown replacement flow is fine for plain text, but it breaks planning-doc tables, header styling, and rich memo cells. This change adds the missing MCP surface needed to update sprint planning docs while preserving the template.

## Verification
- `npm run format`
- `npm test`
- `npm run build`

## Contributor notes
This PR comes from my fork per the repository contributor workflow and closes #113.