### PR TITLE
fix: address PR 114 review 4179726005 issues

### DIFF
--- a/src/googleDocsApiHelpers.tableFormatting.test.ts
+++ b/src/googleDocsApiHelpers.tableFormatting.test.ts
@@ -19,7 +19,7 @@ describe('table formatting request builders', () => {
         rowSpan: 2,
         columnSpan: 3,
         backgroundColor: hexToRgbColor('#D9E2F3')!,
-        contentAlignment: 'CENTER',
+        contentAlignment: 'MIDDLE',
         paddingTopPt: 8,
         borderTop: border,
       },
@@ -41,6 +41,7 @@ describe('table formatting request builders', () => {
     });
     expect(result!.request.updateTableCellStyle!.tableRange!.rowSpan).toBe(2);
     expect(result!.request.updateTableCellStyle!.tableRange!.columnSpan).toBe(3);
+    expect(result!.request.updateTableCellStyle!.tableCellStyle!.contentAlignment).toBe('MIDDLE');
   });
 
   it('builds fixed-width column property requests', () => {

--- a/src/googleDocsApiHelpers.ts
+++ b/src/googleDocsApiHelpers.ts
@@ -719,7 +719,7 @@ export function buildDeleteTableRowRequest(
 
 type TableCellStyleArgs = {
   backgroundColor?: docs_v1.Schema$RgbColor;
-  contentAlignment?: 'CONTENT_ALIGNMENT_UNSPECIFIED' | 'LEFT' | 'CENTER' | 'RIGHT';
+  contentAlignment?: 'CONTENT_ALIGNMENT_UNSPECIFIED' | 'TOP' | 'MIDDLE' | 'BOTTOM';
   rowSpan?: number;
   columnSpan?: number;
   paddingTopPt?: number;

--- a/src/tools/docs/appendTableRows.ts
+++ b/src/tools/docs/appendTableRows.ts
@@ -88,10 +88,30 @@ export function register(server: FastMCP) {
 
         const firstAppendedRowIndex = table.rowCount;
         for (const [offset, rowValues] of args.rows.entries()) {
+          const currentTable =
+            offset === 0
+              ? updatedTable
+              : getTableById(
+                  (
+                    await docs.documents.get({
+                      documentId: args.documentId,
+                      includeTabsContent: true,
+                      fields:
+                        'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+                    })
+                  ).data,
+                  args.tableId,
+                  args.tabId
+                );
+          if (!currentTable) {
+            throw new UserError(
+              `Table "${args.tableId}" could not be re-fetched while populating appended rows.`
+            );
+          }
           await replaceTableRowDataInternal(
             docs,
             args.documentId,
-            updatedTable,
+            currentTable,
             firstAppendedRowIndex + offset,
             rowValues,
             args.tabId

--- a/src/tools/docs/cloneTable.test.ts
+++ b/src/tools/docs/cloneTable.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { extractTableSnapshot, findTableNearestStartIndex } from './structureHelpers.js';
+import { readFileSync } from 'node:fs';
 
 const mockDocument = {
   body: {
@@ -28,7 +29,7 @@ const mockDocument = {
                   endIndex: 25,
                   tableCellStyle: {
                     backgroundColor: { color: { rgbColor: { red: 0.85, green: 0.9, blue: 0.95 } } },
-                    contentAlignment: 'CENTER',
+                    contentAlignment: 'MIDDLE',
                     paddingTop: { magnitude: 6, unit: 'PT' },
                   },
                   content: [
@@ -160,7 +161,7 @@ describe('table snapshot helpers', () => {
     expect(snapshot?.cellStyles[0]).toMatchObject({
       rowIndex: 0,
       columnIndex: 0,
-      contentAlignment: 'CENTER',
+      contentAlignment: 'MIDDLE',
       paddingTopPt: 6,
       hasBoldText: true,
     });
@@ -169,5 +170,10 @@ describe('table snapshot helpers', () => {
   it('finds the table nearest to an insertion index', () => {
     const table = findTableNearestStartIndex(mockDocument, 100);
     expect(table?.tableId).toBe('table:body:1');
+  });
+
+  it('requests tab table text and contentAlignment with the same structure as body tables', () => {
+    const source = readFileSync(new URL('./cloneTable.ts', import.meta.url), 'utf8');
+    expect(source).toContain('contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(');
   });
 });

--- a/src/tools/docs/cloneTable.test.ts
+++ b/src/tools/docs/cloneTable.test.ts
@@ -174,6 +174,8 @@ describe('table snapshot helpers', () => {
 
   it('requests tab table text and contentAlignment with the same structure as body tables', () => {
     const source = readFileSync(new URL('./cloneTable.ts', import.meta.url), 'utf8');
-    expect(source).toContain('contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(');
+    expect(source).toContain(
+      'contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph('
+    );
   });
 });

--- a/src/tools/docs/cloneTable.ts
+++ b/src/tools/docs/cloneTable.ts
@@ -8,6 +8,9 @@ import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { buildInsertTableWithDataRequests } from './insertTableWithData.js';
 import { extractDocumentTables, extractTableSnapshot } from './structureHelpers.js';
 
+const CLONE_TABLE_SOURCE_FIELDS =
+  'body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))))))';
+
 const CloneTableParameters = DocumentIdParameter.extend({
   sourceDocumentId: z.string().min(1).describe('Document ID containing the source table template.'),
   sourceTableId: z.string().min(1).describe('Source MCP table ID from listDocumentTables.'),
@@ -66,8 +69,7 @@ export function register(server: FastMCP) {
         const sourceRes = await docs.documents.get({
           documentId: args.sourceDocumentId,
           includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))),paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan))))))))',
+          fields: CLONE_TABLE_SOURCE_FIELDS,
         });
 
         const snapshot = extractTableSnapshot(sourceRes.data, args.sourceTableId, args.sourceTabId);

--- a/src/tools/docs/formatting/updateTableCellStyle.ts
+++ b/src/tools/docs/formatting/updateTableCellStyle.ts
@@ -10,7 +10,7 @@ const HexColor = z
   .string()
   .refine(validateHexColor, { message: 'Invalid hex color format (e.g., #D9E2F3).' });
 
-const Alignment = z.enum(['LEFT', 'CENTER', 'RIGHT']);
+const Alignment = z.enum(['TOP', 'MIDDLE', 'BOTTOM']);
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -24,7 +24,7 @@ export function register(server: FastMCP) {
       columnStart: z.number().int().min(0).describe('Zero-based starting column index.'),
       columnEnd: z.number().int().min(0).describe('Zero-based ending column index (inclusive).'),
       backgroundColor: HexColor.optional().describe('Cell background color, e.g. "#D9E2F3".'),
-      contentAlignment: Alignment.optional().describe('Horizontal content alignment inside cells.'),
+      contentAlignment: Alignment.optional().describe('Vertical content alignment inside cells.'),
       paddingTopPt: z.number().min(0).optional().describe('Top padding in points.'),
       paddingBottomPt: z.number().min(0).optional().describe('Bottom padding in points.'),
       paddingLeftPt: z.number().min(0).optional().describe('Left padding in points.'),

--- a/src/tools/docs/structureHelpers.ts
+++ b/src/tools/docs/structureHelpers.ts
@@ -46,7 +46,7 @@ export interface ExtractedTableCellStyle {
   rowIndex: number;
   columnIndex: number;
   backgroundColor?: docs_v1.Schema$RgbColor;
-  contentAlignment?: 'CONTENT_ALIGNMENT_UNSPECIFIED' | 'LEFT' | 'CENTER' | 'RIGHT' | null;
+  contentAlignment?: 'CONTENT_ALIGNMENT_UNSPECIFIED' | 'TOP' | 'MIDDLE' | 'BOTTOM' | null;
   paddingTopPt?: number;
   paddingBottomPt?: number;
   paddingLeftPt?: number;
@@ -183,9 +183,9 @@ function normalizeCellStyle(
   if (!style && !firstParagraphHasBoldText) return null;
 
   const contentAlignment =
-    style?.contentAlignment === 'LEFT' ||
-    style?.contentAlignment === 'CENTER' ||
-    style?.contentAlignment === 'RIGHT' ||
+    style?.contentAlignment === 'TOP' ||
+    style?.contentAlignment === 'MIDDLE' ||
+    style?.contentAlignment === 'BOTTOM' ||
     style?.contentAlignment === 'CONTENT_ALIGNMENT_UNSPECIFIED'
       ? style.contentAlignment
       : null;


### PR DESCRIPTION
## What this fixes
- corrects Google Docs table cell `contentAlignment` enum usage to `TOP`/`MIDDLE`/`BOTTOM` across the tool schema, request builder, and style extraction
- fixes the `cloneTable` source fields mask so tab-based source tables return cell content and `contentAlignment`
- prevents stale cell indices during multi-row `appendTableRows` by re-fetching the table before populating each subsequent appended row

## Why
These are the three correctness issues called out in review `4179726005` on PR #114. Each one could cause broken runtime behavior against the Google Docs API or corrupted document output.

## Verification
- `npm test -- --run src/googleDocsApiHelpers.tableFormatting.test.ts src/tools/docs/cloneTable.test.ts src/tools/docs/tableRowDataHelpers.test.ts`
- `npm run build`

## Notes
- This PR is split out because PR #114 did not visibly reflect the local fix commit on GitHub.
- `AGENTS.md` was not included.