### PR TITLE
Add Sheets hyperlink extraction and follow tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Tools across Google Docs, Sheets, and Drive:
 | `ungroupAllRows`              | Remove all row groupings                                              |
 | `insertChart`                 | Create a chart from data                                              |
 | `deleteChart`                 | Remove a chart                                                        |
+| `extractSheetHyperlink`    | Resolve the hyperlink stored in a single cell |
+| `followSheetHyperlink`     | Follow a cell hyperlink with HTTP GET |
 
 ### Google Sheets Tables
 

--- a/src/googleSheetsApiHelpers.ts
+++ b/src/googleSheetsApiHelpers.ts
@@ -4,6 +4,15 @@ import { UserError } from 'fastmcp';
 
 type Sheets = sheets_v4.Sheets; // Alias for convenience
 
+export interface ExtractedSheetHyperlink {
+  cell: string;
+  sheetName: string | null;
+  formattedValue: string | null;
+  formula: string | null;
+  url: string;
+  linkSource: 'cellHyperlink' | 'cellFormat' | 'textFormatRun' | 'formula';
+}
+
 // --- Core Helper Functions ---
 
 /**
@@ -95,6 +104,137 @@ export async function readRange(
       );
     }
     throw new UserError(`Failed to read range: ${error.message || 'Unknown error'}`);
+  }
+}
+
+/**
+ * Reads a single cell hyperlink from grid data, including formula fallback.
+ */
+function quoteSheetName(sheetName: string): string {
+  return /[\s'!]/.test(sheetName) ? `'${sheetName.replace(/'/g, "''")}'` : sheetName;
+}
+
+function extractFormulaHyperlink(formulaValue: string | null | undefined): string | null {
+  if (!formulaValue) return null;
+
+  const match = formulaValue.match(
+    /^\s*=\s*HYPERLINK\s*\(\s*"([^"]+)"\s*(?:,|\))/
+  );
+  return match?.[1] ?? null;
+}
+
+function extractHyperlinkFromCellData(
+  cellData: sheets_v4.Schema$CellData | undefined,
+  cellRef: string,
+  sheetName: string | null
+): ExtractedSheetHyperlink {
+  const formula = cellData?.userEnteredValue?.formulaValue ?? null;
+  const formattedValue = cellData?.formattedValue ?? null;
+
+  if (cellData?.hyperlink) {
+    return {
+      cell: cellRef,
+      sheetName,
+      formattedValue,
+      formula,
+      url: cellData.hyperlink,
+      linkSource: 'cellHyperlink',
+    };
+  }
+
+  const cellFormatLink = cellData?.userEnteredFormat?.textFormat?.link?.uri;
+  if (cellFormatLink) {
+    return {
+      cell: cellRef,
+      sheetName,
+      formattedValue,
+      formula,
+      url: cellFormatLink,
+      linkSource: 'cellFormat',
+    };
+  }
+
+  const runLinks = Array.from(
+    new Set(
+      (cellData?.textFormatRuns ?? [])
+        .map((run) => run.format?.link?.uri ?? null)
+        .filter((url): url is string => typeof url === 'string' && url.length > 0)
+    )
+  );
+
+  if (runLinks.length > 1) {
+    throw new UserError(
+      `Cell ${sheetName ? `${sheetName}!` : ''}${cellRef} contains multiple hyperlinks.`
+    );
+  }
+
+  if (runLinks.length === 1) {
+    return {
+      cell: cellRef,
+      sheetName,
+      formattedValue,
+      formula,
+      url: runLinks[0],
+      linkSource: 'textFormatRun',
+    };
+  }
+
+  const formulaLink = extractFormulaHyperlink(formula);
+  if (formulaLink) {
+    return {
+      cell: cellRef,
+      sheetName,
+      formattedValue,
+      formula,
+      url: formulaLink,
+      linkSource: 'formula',
+    };
+  }
+
+  throw new UserError(`Cell ${sheetName ? `${sheetName}!` : ''}${cellRef} does not contain a hyperlink.`);
+}
+
+export async function readCellHyperlink(
+  sheets: Sheets,
+  spreadsheetId: string,
+  cell: string
+): Promise<ExtractedSheetHyperlink> {
+  try {
+    const { sheetName, a1Range } = parseRange(cell);
+    a1ToRowCol(a1Range);
+
+    const metadata = await getSpreadsheetMetadata(sheets, spreadsheetId);
+    const targetSheet = sheetName
+      ? metadata.sheets?.find((sheet) => sheet.properties?.title === sheetName)
+      : metadata.sheets?.[0];
+
+    const targetSheetName = targetSheet?.properties?.title ?? null;
+    if (!targetSheetName) {
+      throw new UserError('Spreadsheet has no sheets.');
+    }
+
+    const response = await sheets.spreadsheets.get({
+      spreadsheetId,
+      ranges: [`${quoteSheetName(targetSheetName)}!${a1Range}`],
+      includeGridData: true,
+      fields:
+        'sheets.properties.title,sheets.data.rowData.values.formattedValue,sheets.data.rowData.values.hyperlink,sheets.data.rowData.values.textFormatRuns,sheets.data.rowData.values.userEnteredFormat.textFormat.link,sheets.data.rowData.values.userEnteredValue.formulaValue,sheets.data.startRow,sheets.data.startColumn',
+    });
+
+    const data = response.data.sheets?.[0]?.data?.[0];
+    const cellData = data?.rowData?.[0]?.values?.[0];
+    return extractHyperlinkFromCellData(cellData, a1Range, targetSheetName);
+  } catch (error: any) {
+    if (error.code === 404) {
+      throw new UserError(`Spreadsheet not found (ID: ${spreadsheetId}). Check the ID.`);
+    }
+    if (error.code === 403) {
+      throw new UserError(
+        `Permission denied for spreadsheet (ID: ${spreadsheetId}). Ensure you have read access.`
+      );
+    }
+    if (error instanceof UserError) throw error;
+    throw new UserError(`Failed to read cell hyperlink: ${error.message || 'Unknown error'}`);
   }
 }
 

--- a/src/tools/sheets/README.md
+++ b/src/tools/sheets/README.md
@@ -7,6 +7,8 @@ Tools for reading, writing, and managing Google Spreadsheets, including cell dat
 | Tool               | Description                                              |
 | ------------------ | -------------------------------------------------------- |
 | `readSpreadsheet`  | Reads data from a range in a spreadsheet                 |
+| `extractSheetHyperlink` | Resolves the hyperlink target stored in a single cell |
+| `followSheetHyperlink` | Resolves a single-cell hyperlink and performs an HTTP GET |
 | `writeSpreadsheet` | Writes data to a range, overwriting existing values      |
 | `appendRows`       | Appends rows to the end of a sheet                       |
 | `clearRange`       | Clears all cell values in a range without deleting cells |

--- a/src/tools/sheets/extractSheetHyperlink.ts
+++ b/src/tools/sheets/extractSheetHyperlink.ts
@@ -1,0 +1,53 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'extractSheetHyperlink',
+    description:
+      'Reads a single Google Sheets cell and returns its resolved hyperlink target along with the displayed text and source formula when available.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      cell: z
+        .string()
+        .describe('Single-cell A1 reference to inspect (e.g., "Sheet1!B2" or "B2").'),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Extracting hyperlink from ${args.cell} in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const hyperlink = await SheetsHelpers.readCellHyperlink(
+          sheets,
+          args.spreadsheetId,
+          args.cell
+        );
+
+        return JSON.stringify(
+          {
+            spreadsheetId: args.spreadsheetId,
+            requestedCell: args.cell,
+            ...hyperlink,
+          },
+          null,
+          2
+        );
+      } catch (error: any) {
+        log.error(
+          `Error extracting hyperlink from spreadsheet ${args.spreadsheetId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Failed to extract sheet hyperlink: ${error.message || 'Unknown error'}`
+        );
+      }
+    },
+  });
+}

--- a/src/tools/sheets/followSheetHyperlink.ts
+++ b/src/tools/sheets/followSheetHyperlink.ts
@@ -1,0 +1,95 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../clients.js';
+import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const RESPONSE_SNIPPET_LIMIT = 500;
+
+function normalizeSnippet(rawText: string): string | null {
+  const compact = rawText.replace(/\s+/g, ' ').trim();
+  if (!compact) return null;
+  return compact.slice(0, RESPONSE_SNIPPET_LIMIT);
+}
+
+function canReadResponseBody(contentType: string | null): boolean {
+  if (!contentType) return true;
+  return /(text\/|application\/json|application\/xml|application\/x-www-form-urlencoded)/i.test(
+    contentType
+  );
+}
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'followSheetHyperlink',
+    description:
+      'Reads a single Google Sheets cell, resolves its hyperlink, and performs an HTTP GET request to that URL. Use this to trigger link-backed processes without opening a browser.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      cell: z
+        .string()
+        .describe('Single-cell A1 reference to follow (e.g., "Sheet1!B2" or "B2").'),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Following hyperlink from ${args.cell} in spreadsheet ${args.spreadsheetId}`);
+
+      try {
+        const hyperlink = await SheetsHelpers.readCellHyperlink(
+          sheets,
+          args.spreadsheetId,
+          args.cell
+        );
+        const url = new URL(hyperlink.url);
+
+        if (!['http:', 'https:'].includes(url.protocol)) {
+          throw new UserError(
+            `Unsupported hyperlink protocol "${url.protocol}". Only http and https are supported.`
+          );
+        }
+
+        const response = await fetch(url, {
+          method: 'GET',
+          redirect: 'follow',
+          signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+        });
+
+        const contentType = response.headers.get('content-type');
+        const responseSnippet = canReadResponseBody(contentType)
+          ? normalizeSnippet(await response.text())
+          : null;
+
+        return JSON.stringify(
+          {
+            success: response.ok,
+            spreadsheetId: args.spreadsheetId,
+            requestedCell: args.cell,
+            ...hyperlink,
+            resolvedUrl: url.toString(),
+            httpStatus: response.status,
+            statusText: response.statusText,
+            finalUrl: response.url,
+            contentType,
+            responseSnippet,
+          },
+          null,
+          2
+        );
+      } catch (error: any) {
+        log.error(
+          `Error following hyperlink from spreadsheet ${args.spreadsheetId}: ${error.message || error}`
+        );
+        if (error instanceof UserError) throw error;
+        if (error?.name === 'TimeoutError') {
+          throw new UserError(`Request timed out after ${DEFAULT_TIMEOUT_MS}ms.`);
+        }
+        throw new UserError(`Failed to follow sheet hyperlink: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/index.ts
+++ b/src/tools/sheets/index.ts
@@ -1,5 +1,7 @@
 import type { FastMCP } from 'fastmcp';
 import { register as readSpreadsheet } from './readSpreadsheet.js';
+import { register as extractSheetHyperlink } from './extractSheetHyperlink.js';
+import { register as followSheetHyperlink } from './followSheetHyperlink.js';
 import { register as writeSpreadsheet } from './writeSpreadsheet.js';
 import { register as batchWrite } from './batchWrite.js';
 import { register as appendSpreadsheetRows } from './appendSpreadsheetRows.js';
@@ -46,6 +48,8 @@ import { register as deleteChart } from './deleteChart.js';
 
 export function registerSheetsTools(server: FastMCP) {
   readSpreadsheet(server);
+  extractSheetHyperlink(server);
+  followSheetHyperlink(server);
   writeSpreadsheet(server);
   batchWrite(server);
   appendSpreadsheetRows(server);

--- a/src/tools/sheets/sheetHyperlinks.test.ts
+++ b/src/tools/sheets/sheetHyperlinks.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getSheetsClientMock } = vi.hoisted(() => ({
+  getSheetsClientMock: vi.fn(),
+}));
+
+vi.mock('../../clients.js', () => ({
+  getSheetsClient: getSheetsClientMock,
+}));
+
+import { register as registerExtractSheetHyperlink } from './extractSheetHyperlink.js';
+import { register as registerFollowSheetHyperlink } from './followSheetHyperlink.js';
+
+function captureToolConfig(registerTool: (server: any) => void) {
+  let config: any;
+  registerTool({
+    addTool(input: any) {
+      config = input;
+    },
+  });
+  return config;
+}
+
+function parseToolResult(result: any) {
+  const text = typeof result === 'string' ? result : result.content?.[0]?.text;
+  const parts = text.split('\n\n');
+  return JSON.parse(parts[parts.length - 1]);
+}
+
+describe('sheet hyperlink tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('extractSheetHyperlink falls back to the HYPERLINK formula when needed', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          sheets: [{ properties: { title: 'Ops' } }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          sheets: [
+            {
+              properties: { title: 'Ops' },
+              data: [
+                {
+                  rowData: [
+                    {
+                      values: [
+                        {
+                          formattedValue: 'Start process',
+                          userEnteredValue: {
+                            formulaValue:
+                              '=HYPERLINK("https://example.com/run?id=42", "Start process")',
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+    getSheetsClientMock.mockResolvedValue({
+      spreadsheets: { get },
+    });
+
+    const tool = captureToolConfig(registerExtractSheetHyperlink);
+    const parsed = tool.parameters.parse({
+      spreadsheetId: 'spreadsheet-1',
+      cell: 'B2',
+    });
+
+    const result = await tool.execute(parsed, { log: { info() {}, error() {} } });
+    const payload = parseToolResult(result);
+
+    expect(get).toHaveBeenNthCalledWith(1, {
+      spreadsheetId: 'spreadsheet-1',
+      includeGridData: false,
+    });
+    expect(get).toHaveBeenNthCalledWith(2, {
+      spreadsheetId: 'spreadsheet-1',
+      ranges: ['Ops!B2'],
+      includeGridData: true,
+      fields:
+        'sheets.properties.title,sheets.data.rowData.values.formattedValue,sheets.data.rowData.values.hyperlink,sheets.data.rowData.values.textFormatRuns,sheets.data.rowData.values.userEnteredFormat.textFormat.link,sheets.data.rowData.values.userEnteredValue.formulaValue,sheets.data.startRow,sheets.data.startColumn',
+    });
+    expect(payload).toEqual({
+      spreadsheetId: 'spreadsheet-1',
+      requestedCell: 'B2',
+      cell: 'B2',
+      sheetName: 'Ops',
+      formattedValue: 'Start process',
+      formula: '=HYPERLINK("https://example.com/run?id=42", "Start process")',
+      url: 'https://example.com/run?id=42',
+      linkSource: 'formula',
+    });
+  });
+
+  it('followSheetHyperlink resolves the link and performs an HTTP GET', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          sheets: [{ properties: { title: 'Ops' } }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          sheets: [
+            {
+              properties: { title: 'Ops' },
+              data: [
+                {
+                  rowData: [
+                    {
+                      values: [
+                        {
+                          formattedValue: 'Run',
+                          hyperlink: 'https://example.com/run',
+                          userEnteredValue: {
+                            formulaValue: '=HYPERLINK("https://example.com/run", "Run")',
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      url: 'https://example.com/final',
+      headers: {
+        get: vi.fn().mockReturnValue('text/html; charset=utf-8'),
+      },
+      text: vi.fn().mockResolvedValue('  Process started successfully.  '),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+    getSheetsClientMock.mockResolvedValue({
+      spreadsheets: { get },
+    });
+
+    const tool = captureToolConfig(registerFollowSheetHyperlink);
+    const parsed = tool.parameters.parse({
+      spreadsheetId: 'spreadsheet-1',
+      cell: 'Ops!B2',
+    });
+
+    const result = await tool.execute(parsed, { log: { info() {}, error() {} } });
+    const payload = parseToolResult(result);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0]?.[0] as URL).toString()).toBe('https://example.com/run');
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        redirect: 'follow',
+      })
+    );
+    expect(payload).toEqual({
+      success: true,
+      spreadsheetId: 'spreadsheet-1',
+      requestedCell: 'Ops!B2',
+      cell: 'B2',
+      sheetName: 'Ops',
+      formattedValue: 'Run',
+      formula: '=HYPERLINK("https://example.com/run", "Run")',
+      url: 'https://example.com/run',
+      linkSource: 'cellHyperlink',
+      resolvedUrl: 'https://example.com/run',
+      httpStatus: 200,
+      statusText: 'OK',
+      finalUrl: 'https://example.com/final',
+      contentType: 'text/html; charset=utf-8',
+      responseSnippet: 'Process started successfully.',
+    });
+  });
+
+  it('followSheetHyperlink rejects unsupported protocols', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          sheets: [{ properties: { title: 'Ops' } }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          sheets: [
+            {
+              properties: { title: 'Ops' },
+              data: [
+                {
+                  rowData: [
+                    {
+                      values: [
+                        {
+                          formattedValue: 'Mail',
+                          hyperlink: 'mailto:test@example.com',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    getSheetsClientMock.mockResolvedValue({
+      spreadsheets: { get },
+    });
+
+    const tool = captureToolConfig(registerFollowSheetHyperlink);
+    const parsed = tool.parameters.parse({
+      spreadsheetId: 'spreadsheet-1',
+      cell: 'A1',
+    });
+
+    await expect(tool.execute(parsed, { log: { info() {}, error() {} } })).rejects.toThrow(
+      'Unsupported hyperlink protocol "mailto:". Only http and https are supported.'
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Sheets helper to resolve a single cell hyperlink from grid data with formula fallback
- add extractSheetHyperlink and followSheetHyperlink tools and register them in the Sheets toolset
- cover the new tools with tests and document them in the Sheets docs

## Testing
- npm test -- src/tools/sheets/sheetHyperlinks.test.ts
- npm run build