### PR TITLE
[Bug] Fix "Field mask cannot retrieve comment-specific fields" on tabId-targeted operations

### DIFF
--- a/src/markdown-transformer/index.ts
+++ b/src/markdown-transformer/index.ts
@@ -102,7 +102,7 @@ export async function extractMarkdown(
   const res = await docs.documents.get({
     documentId,
     includeTabsContent: !!tabId,
-    fields: tabId ? '*' : '*',
+    fields: 'title,documentId,body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects))',
   });
 
   if (tabId) {

--- a/src/markdown-transformer/index.ts
+++ b/src/markdown-transformer/index.ts
@@ -103,7 +103,7 @@ export async function extractMarkdown(
     documentId,
     includeTabsContent: !!tabId,
     fields: tabId
-      ? 'title,documentId,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists))'
+      ? 'title,documentId,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects))'
       : 'title,documentId,body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects',
   });
 

--- a/src/markdown-transformer/index.ts
+++ b/src/markdown-transformer/index.ts
@@ -102,7 +102,9 @@ export async function extractMarkdown(
   const res = await docs.documents.get({
     documentId,
     includeTabsContent: !!tabId,
-    fields: 'title,documentId,body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects))',
+    fields: tabId
+      ? 'title,documentId,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists))'
+      : 'title,documentId,body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects',
   });
 
   if (tabId) {

--- a/src/tools/docs/appendToGoogleDoc.ts
+++ b/src/tools/docs/appendToGoogleDoc.ts
@@ -41,7 +41,7 @@ export function register(server: FastMCP) {
         const docInfo = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: needsTabsContent,
-          fields: needsTabsContent ? 'tabs' : 'body(content(endIndex)),documentStyle(pageSize)',
+          fields: needsTabsContent ? 'tabs(tabProperties,documentTab(body(content(endIndex)),documentStyle(pageSize)))' : 'body(content(endIndex)),documentStyle(pageSize)',
         });
 
         let endIndex = 1;

--- a/src/tools/docs/deleteRange.ts
+++ b/src/tools/docs/deleteRange.ts
@@ -50,7 +50,7 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab)',
+            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/docs/insertImage.ts
+++ b/src/tools/docs/insertImage.ts
@@ -54,7 +54,7 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab)',
+            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/docs/insertPageBreak.ts
+++ b/src/tools/docs/insertPageBreak.ts
@@ -36,7 +36,7 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab)',
+            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/docs/insertTable.ts
+++ b/src/tools/docs/insertTable.ts
@@ -38,7 +38,7 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab)',
+            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/docs/insertText.ts
+++ b/src/tools/docs/insertText.ts
@@ -38,7 +38,7 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab)',
+            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/docs/listDocumentTabs.ts
+++ b/src/tools/docs/listDocumentTabs.ts
@@ -28,8 +28,8 @@ export function register(server: FastMCP) {
           includeTabsContent: true,
           // Only get essential fields for tab listing
           fields: args.includeContent
-            ? 'title,tabs' // Get all tab data if we need content summary
-            : 'title,tabs(tabProperties,childTabs)', // Otherwise just structure
+            ? 'title,tabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties))),documentTab(body(content(endIndex))))' // Explicit fields to avoid comment-field validation
+            : 'title,tabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties))))', // Recursive structure only
         });
 
         const docTitle = res.data.title || 'Untitled Document';

--- a/src/tools/docs/readGoogleDoc.ts
+++ b/src/tools/docs/readGoogleDoc.ts
@@ -50,7 +50,7 @@ export function register(server: FastMCP) {
         const res = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: needsTabsContent,
-          fields: needsTabsContent ? '*' : fields, // Get full document if using tabs
+          fields: needsTabsContent ? 'title,documentId,body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects))' : fields,
         });
         log.info(`Fetched doc: ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`);
 

--- a/src/tools/docs/readGoogleDoc.ts
+++ b/src/tools/docs/readGoogleDoc.ts
@@ -50,7 +50,7 @@ export function register(server: FastMCP) {
         const res = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: needsTabsContent,
-          fields: needsTabsContent ? 'title,documentId,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists))' : fields,
+          fields: needsTabsContent ? 'title,documentId,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects))' : fields,
         });
         log.info(`Fetched doc: ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`);
 

--- a/src/tools/docs/readGoogleDoc.ts
+++ b/src/tools/docs/readGoogleDoc.ts
@@ -50,7 +50,7 @@ export function register(server: FastMCP) {
         const res = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: needsTabsContent,
-          fields: needsTabsContent ? 'title,documentId,body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects))' : fields,
+          fields: needsTabsContent ? 'title,documentId,inlineObjects,positionedObjects,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists))' : fields,
         });
         log.info(`Fetched doc: ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`);
 

--- a/src/tools/utils/appendMarkdownToGoogleDoc.ts
+++ b/src/tools/utils/appendMarkdownToGoogleDoc.ts
@@ -43,7 +43,7 @@ export function register(server: FastMCP) {
         const doc = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: !!args.tabId,
-          fields: args.tabId ? 'tabs' : 'body(content(endIndex))',
+          fields: args.tabId ? 'tabs(tabProperties,documentTab(body(content(endIndex))))' : 'body(content(endIndex))',
         });
 
         let bodyContent: any;

--- a/src/tools/utils/replaceDocumentWithMarkdown.ts
+++ b/src/tools/utils/replaceDocumentWithMarkdown.ts
@@ -47,7 +47,7 @@ export function register(server: FastMCP) {
         const doc = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: !!args.tabId,
-          fields: args.tabId ? 'tabs' : 'body(content(startIndex,endIndex))',
+          fields: args.tabId ? 'tabs(tabProperties,documentTab(body(content(startIndex,endIndex))))' : 'body(content(startIndex,endIndex))',
         });
 
         // 2. Calculate replacement range
@@ -111,7 +111,7 @@ export function register(server: FastMCP) {
           const docAfterDelete = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: !!args.tabId,
-            fields: args.tabId ? 'tabs' : 'body(content(startIndex,endIndex))',
+            fields: args.tabId ? 'tabs(tabProperties,documentTab(body(content(startIndex,endIndex))))' : 'body(content(startIndex,endIndex))',
           });
 
           let survivorContent: any;


### PR DESCRIPTION
## Problem

Every tabId-targeted write/read operation fails with:

> Field mask cannot retrieve comment-specific fields when include_comments is false

This started failing recently after Google tightened their Docs API validation around comment-related sub-fields in the Document/Tab schema.

## Repro

1. Open any Google Doc with multiple tabs
2. Call `appendMarkdown` (or `insertText`, `readDocument`, `listTabs`, etc.) with a `tabId` parameter
3. → API returns the error above

## Root cause

Several tools use overly broad field masks like `'tabs'`, `'tabs(tabProperties,documentTab)'`, or `'*'` when `tabId` is provided. Google's API now treats these as matching comment-specific sub-fields and rejects the request unless `include_comments: true` is also set.

## Fix

Replace all broad field masks with explicit sub-field paths that request only the data each tool actually needs. No functional regression — the same data is returned, just without accidentally requesting comment fields.

### Affected tools

| Tool | Previous mask | Fixed mask |
|---|---|---|
| `appendMarkdown` | `'tabs'` | `'tabs(tabProperties,documentTab(body(content(endIndex))))'` |
| `appendText` | `'tabs'` | `'tabs(tabProperties,documentTab(body(content(endIndex)),documentStyle(pageSize)))'` |
| `insertText` | `'tabs(tabProperties,documentTab)'` | `'tabs(tabProperties,documentTab(body(content(endIndex))))'` |
| `insertImage` | `'tabs(tabProperties,documentTab)'` | `'tabs(tabProperties,documentTab(body(content(endIndex))))'` |
| `insertTable` | `'tabs(tabProperties,documentTab)'` | `'tabs(tabProperties,documentTab(body(content(endIndex))))'` |
| `insertPageBreak` | `'tabs(tabProperties,documentTab)'` | `'tabs(tabProperties,documentTab(body(content(endIndex))))'` |
| `deleteRange` | `'tabs(tabProperties,documentTab)'` | `'tabs(tabProperties,documentTab(body(content(endIndex))))'` |
| `replaceDocumentWithMarkdown` | `'tabs'` | `'tabs(tabProperties,documentTab(body(content(startIndex,endIndex))))'` |
| `listTabs` | `'title,tabs'` | Explicit recursive `tabProperties,childTabs(...)` + `documentTab(body(...))` |
| `readDocument` | `'*'` | Explicit field list without comment fields |
| `extractMarkdown` | `'*'` | Same explicit field list |

## Tests

All 217 existing vitest tests pass. Manually verified against a multi-tab document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)