### PR TITLE
fix: define spreadsheet cell value schemas

### DIFF
--- a/src/tools/sheets/appendSpreadsheetRows.ts
+++ b/src/tools/sheets/appendSpreadsheetRows.ts
@@ -3,6 +3,7 @@ import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getSheetsClient } from '../../clients.js';
 import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+import { SpreadsheetCellValueSchema } from '../../types.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -21,7 +22,7 @@ export function register(server: FastMCP) {
           'A1 notation range indicating where to append (e.g., "A1" or "Sheet1!A1"). Data will be appended starting from this range.'
         ),
       values: z
-        .array(z.array(z.any()))
+        .array(z.array(SpreadsheetCellValueSchema))
         .describe('2D array of values to append. Each inner array represents a row.'),
       valueInputOption: z
         .enum(['RAW', 'USER_ENTERED'])

--- a/src/tools/sheets/appendTableRows.ts
+++ b/src/tools/sheets/appendTableRows.ts
@@ -3,6 +3,7 @@ import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getSheetsClient } from '../../clients.js';
 import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+import { SpreadsheetCellValueSchema } from '../../types.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -21,7 +22,7 @@ export function register(server: FastMCP) {
           'The table name or table ID to append rows to. Use listTables to see available tables.'
         ),
       values: z
-        .array(z.array(z.any()))
+        .array(z.array(SpreadsheetCellValueSchema))
         .min(1)
         .describe('2D array of values to append. Each inner array represents a row.'),
       valueInputOption: z

--- a/src/tools/sheets/batchWrite.ts
+++ b/src/tools/sheets/batchWrite.ts
@@ -2,6 +2,7 @@ import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getSheetsClient } from '../../clients.js';
+import { SpreadsheetCellValueSchema } from '../../types.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -19,7 +20,7 @@ export function register(server: FastMCP) {
           z.object({
             range: z.string().describe('A1 notation range (e.g., "Sheet1!A1:B2").'),
             values: z
-              .array(z.array(z.any()))
+              .array(z.array(SpreadsheetCellValueSchema))
               .describe('2D array of values to write. Each inner array represents a row.'),
           })
         )

--- a/src/tools/sheets/createSpreadsheet.ts
+++ b/src/tools/sheets/createSpreadsheet.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { drive_v3 } from 'googleapis';
 import { getDriveClient, getSheetsClient } from '../../clients.js';
 import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+import { SpreadsheetCellValueSchema } from '../../types.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -19,7 +20,7 @@ export function register(server: FastMCP) {
           'ID of folder where spreadsheet should be created. If not provided, creates in Drive root.'
         ),
       initialData: z
-        .array(z.array(z.any()))
+        .array(z.array(SpreadsheetCellValueSchema))
         .optional()
         .describe(
           'Optional initial data to populate in the first sheet. Each inner array represents a row.'

--- a/src/tools/sheets/spreadsheetValueSchema.test.ts
+++ b/src/tools/sheets/spreadsheetValueSchema.test.ts
@@ -1,0 +1,61 @@
+import type { FastMCP } from 'fastmcp';
+import { describe, expect, it } from 'vitest';
+import { toJsonSchema } from 'xsschema';
+import { register as registerAppendRows } from './appendSpreadsheetRows.js';
+import { register as registerAppendTableRows } from './appendTableRows.js';
+import { register as registerBatchWrite } from './batchWrite.js';
+import { register as registerCreateSpreadsheet } from './createSpreadsheet.js';
+import { register as registerWriteSpreadsheet } from './writeSpreadsheet.js';
+
+type ToolConfig = Parameters<FastMCP['addTool']>[0];
+
+function captureTool(register: (server: FastMCP) => void): ToolConfig {
+  let captured: ToolConfig | undefined;
+  const server = {
+    addTool: (tool: ToolConfig) => {
+      captured = tool;
+    },
+  };
+
+  register(server as FastMCP);
+
+  if (!captured) throw new Error('Tool registration did not call addTool.');
+  return captured;
+}
+
+async function buildInputSchema(tool: ToolConfig) {
+  if (!tool.parameters) throw new Error(`${tool.name} has no parameter schema.`);
+  return toJsonSchema(tool.parameters) as Promise<any>;
+}
+
+function expectNestedArrayItems(schema: any, propertyPath: string[]) {
+  const schemaProperty = propertyPath.reduce((current, key) => current?.properties?.[key], schema);
+
+  expect(schemaProperty?.items).toBeDefined();
+  expect(schemaProperty.items?.items).toBeDefined();
+}
+
+describe('spreadsheet value tool schemas', () => {
+  it.each([
+    [registerWriteSpreadsheet, ['values']],
+    [registerAppendRows, ['values']],
+    [registerAppendTableRows, ['values']],
+    [registerCreateSpreadsheet, ['initialData']],
+    [registerBatchWrite, ['data', 'items', 'values']],
+  ] as const)(
+    'defines JSON Schema items for nested cell arrays',
+    async (register, propertyPath) => {
+      const tool = captureTool(register);
+      const schema = await buildInputSchema(tool);
+
+      if (propertyPath[1] === 'items') {
+        const dataItems = schema.properties?.data?.items;
+        expect(dataItems).toBeDefined();
+        expectNestedArrayItems(dataItems, ['values']);
+        return;
+      }
+
+      expectNestedArrayItems(schema, [...propertyPath]);
+    }
+  );
+});

--- a/src/tools/sheets/writeSpreadsheet.ts
+++ b/src/tools/sheets/writeSpreadsheet.ts
@@ -3,6 +3,7 @@ import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getSheetsClient } from '../../clients.js';
 import * as SheetsHelpers from '../../googleSheetsApiHelpers.js';
+import { SpreadsheetCellValueSchema } from '../../types.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -19,7 +20,7 @@ export function register(server: FastMCP) {
         .string()
         .describe('A1 notation range to write to (e.g., "A1:B2" or "Sheet1!A1:B2").'),
       values: z
-        .array(z.array(z.any()).max(500))
+        .array(z.array(SpreadsheetCellValueSchema).max(500))
         .max(500)
         .describe('2D array of values to write. Each inner array represents a row.'),
       valueInputOption: z

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,9 @@ export const ParagraphStyleParameters = z
 // Subset of ParagraphStyle used for passing to helpers
 export type ParagraphStyleArgs = z.infer<typeof ParagraphStyleParameters>;
 
+export const SpreadsheetCellValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+export type SpreadsheetCellValue = z.infer<typeof SpreadsheetCellValueSchema>;
+
 // --- Combination Schemas for Tools ---
 
 export const ApplyTextStyleToolParameters = DocumentIdParameter.extend({


### PR DESCRIPTION
## Summary
- Fixes spreadsheet write/append/create tool schemas by replacing untyped `z.any()` cell arrays with a concrete spreadsheet cell value schema.
- Adds regression coverage that converts affected tool parameters to JSON Schema and verifies nested array `items` schemas are present.

## Testing
- `npx vitest run src/tools/sheets/spreadsheetValueSchema.test.ts`
- `npm test`
- `npm run build`
- `npm run format:check`

Fixes #101