### PR TITLE
fix: sanitize filename in Content-Disposition to prevent CRLF header injection (CWE-93)

### DIFF
--- a/src/downloadProxy.test.ts
+++ b/src/downloadProxy.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeFileName } from './downloadProxy.js';
+
+describe('sanitizeFileName', () => {
+  it('should pass through normal filenames unchanged', () => {
+    expect(sanitizeFileName('report.pdf')).toBe('report.pdf');
+    expect(sanitizeFileName('My Document (2).docx')).toBe('My Document (2).docx');
+  });
+
+  it('should strip CR and LF characters to prevent header injection', () => {
+    expect(sanitizeFileName('evil\r\nSet-Cookie: pwn=1')).toBe('evilSet-Cookie: pwn=1');
+    expect(sanitizeFileName('evil\nInjected: yes')).toBe('evilInjected: yes');
+    expect(sanitizeFileName('evil\rInjected: yes')).toBe('evilInjected: yes');
+  });
+
+  it('should strip null bytes', () => {
+    expect(sanitizeFileName('evil\x00.pdf')).toBe('evil.pdf');
+  });
+
+  it('should produce a valid Content-Disposition header value', () => {
+    // Filenames with quotes should be safely escaped
+    const name = sanitizeFileName('file "with" quotes.pdf');
+    const header = `attachment; filename="${name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    // Should not throw when set on Headers
+    const h = new Headers();
+    h.set('Content-Disposition', header);
+    expect(h.get('Content-Disposition')).toContain('file');
+  });
+
+  it('should produce a valid header even with CRLF in filename', () => {
+    const name = sanitizeFileName('evil\r\nSet-Cookie: pwn=1');
+    const header = `attachment; filename="${name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    const h = new Headers();
+    // This must NOT throw
+    h.set('Content-Disposition', header);
+    expect(h.get('Content-Disposition')).toBeDefined();
+  });
+
+  it('should handle filenames with backslash before quote', () => {
+    // Backslash-quote edge case: a literal backslash followed by quote
+    const name = sanitizeFileName('file\\.pdf');
+    expect(name).toBe('file\\.pdf');
+  });
+
+  it('should fallback to "download" for empty filename after sanitization', () => {
+    expect(sanitizeFileName('\r\n\r\n')).toBe('download');
+    expect(sanitizeFileName('\x00')).toBe('download');
+    expect(sanitizeFileName('')).toBe('download');
+  });
+});

--- a/src/downloadProxy.ts
+++ b/src/downloadProxy.ts
@@ -22,6 +22,17 @@ setInterval(() => {
   for (const [k, v] of pending) if (v.expiresAt < now) pending.delete(k);
 }, 60_000).unref();
 
+/**
+ * Sanitise a filename for safe use in a Content-Disposition header.
+ * Strips CR, LF, and NUL characters that could cause header injection or
+ * trigger an error in the `Headers` API. Falls back to "download" when the
+ * result would be empty.
+ */
+export function sanitizeFileName(name: string): string {
+  const sanitized = name.replace(/[\r\n\0]/g, '');
+  return sanitized || 'download';
+}
+
 export function createDownloadToken(opts: Omit<PendingDownload, 'expiresAt'>): string {
   const token = crypto.randomUUID();
   pending.set(token, { ...opts, expiresAt: Date.now() + 5 * 60 * 1000 });
@@ -42,9 +53,10 @@ export function registerDownloadRoute(server: FastMCP): void {
     auth.setCredentials({ access_token: entry.accessToken });
     const drive = google.drive({ version: 'v3', auth });
 
+    const safeName = sanitizeFileName(entry.fileName);
     c.header(
       'Content-Disposition',
-      `attachment; filename="${entry.fileName.replace(/"/g, '\\"')}"`
+      `attachment; filename="${safeName.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
     );
 
     if (entry.isWorkspace && entry.exportMime) {


### PR DESCRIPTION
## Summary

This PR fixes an HTTP header injection / DoS issue in the remote download proxy (`src/downloadProxy.ts`) where an attacker-controlled Google Drive filename is interpolated into the `Content-Disposition` response header without stripping CR/LF/NUL characters.

- **CWE:** [CWE-93 — Improper Neutralization of CRLF Sequences](https://cwe.mitre.org/data/definitions/93.html)
- **File:** `src/downloadProxy.ts`, route handler registered in `registerDownloadRoute`
- **Severity:** Low–Moderate (depends on Hono runtime adapter)

## Vulnerability details

The download route built the header like this:

```ts
c.header(
  'Content-Disposition',
  `attachment; filename="${entry.fileName.replace(/"/g, '\\"')}"`
);
```

`entry.fileName` originates from Google Drive file metadata captured in `createDownloadToken(...)` and is fully attacker-controlled — Drive permits filenames containing `\r` and `\n`. Only `"` was escaped, so a filename such as:

```
evil\r\nSet-Cookie: pwn=1
```

is interpolated verbatim into the header line. Two outcomes are possible depending on the runtime:

1. **On Node.js (current default adapter):** the `Headers` API throws a `TypeError` for header values containing CR/LF, surfacing as an unhandled error in the request handler and producing a 500 — a per-download DoS triggered by anyone who can share a file with the victim.
2. **On runtimes with looser header validation** (some Workers/Bun/Deno configurations, or downstream proxies): the CRLF can split the header, allowing injection of additional response headers (e.g. `Set-Cookie`, cache-control) within the response served to the victim.

### Data flow

1. Attacker creates/shares a Drive file named `foo\r\nX-Injected: 1.pdf` with the victim.
2. Victim's MCP agent calls a tool that produces a download token; `createDownloadToken({ fileName, ... })` stores the unsanitised name.
3. Victim follows the `/download/:token` URL.
4. Handler reads `entry.fileName` and writes it into the `Content-Disposition` header — header injection or DoS, depending on adapter.

## Fix

Introduce a tiny `sanitizeFileName()` helper that strips the three characters that are dangerous in a header value (`\r`, `\n`, `\0`) and falls back to `"download"` if the result is empty. Also escape backslashes in addition to quotes so the quoted-string form of `filename=` remains well-formed.

```ts
export function sanitizeFileName(name: string): string {
  const sanitized = name.replace(/[\r\n\0]/g, '');
  return sanitized || 'download';
}

const safeName = sanitizeFileName(entry.fileName);
c.header(
  'Content-Disposition',
  `attachment; filename="${safeName.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
);
```

The change is intentionally minimal — no new dependencies, no behavioural change for any well-formed filename. Filenames with normal characters (spaces, parentheses, unicode, quotes) are unaffected.

## Tests

Added `src/downloadProxy.test.ts` covering:

- normal filenames pass through unchanged;
- CR, LF, and CRLF sequences are stripped;
- NUL bytes are stripped;
- the resulting header value can be set on a `Headers` object without throwing (this is the regression check — pre-fix input throws here);
- empty/all-stripped filenames fall back to `"download"`;
- backslash handling is correct.

Full test suite: **179/179 passing** (`npm test`).

## Security analysis

The bug is reachable from a low-privilege attacker: they only need the ability to share a Drive file with the victim, which is the normal collaborative workflow Drive is designed for. The victim does not need to do anything unusual — clicking a download link generated by their MCP agent is enough. There is no authentication boundary between Drive metadata and the response header, and the prior `replace(/"/g, '\\"')` only covered the quoted-string escape, not header-value validity.

The fix removes both failure modes: the `Headers` API can no longer throw on the constructed value, and there are no CR/LF bytes that could be interpreted as a header separator by any downstream component.

### Adversarial review

Before submitting, I tried to disprove this. The most plausible existing mitigation is the Node `Headers` implementation rejecting CR/LF — but that only converts the issue from injection to DoS, and the project documents deploying the remote MCP behind non-Node adapters (Workers/Bun) where header validation is implementation-defined and historically inconsistent. The preconditions (sharing a file, victim downloading) do not in themselves grant the attacker any ability to manipulate the victim's HTTP responses — that capability comes specifically from this bug. The fix is also strictly defensive: it cannot break any legitimate filename, since CR/LF/NUL are not valid in user-visible filenames on any major OS.

cc @lewiswigmore
