### PR TITLE
fix: add suggestionsViewMode to documents.get calls in tab write tools

### DIFF
--- a/src/tools/docs/appendToGoogleDoc.ts
+++ b/src/tools/docs/appendToGoogleDoc.ts
@@ -41,8 +41,9 @@ export function register(server: FastMCP) {
         const docInfo = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: needsTabsContent,
+          suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
           fields: needsTabsContent
-            ? 'tabs(tabProperties,documentTab(body(content(endIndex)),documentStyle(pageSize)))'
+            ? 'tabs(tabProperties(tabId),documentTab(body(content(endIndex))))'
             : 'body(content(endIndex)),documentStyle(pageSize)',
         });
 

--- a/src/tools/docs/insertTableWithData.ts
+++ b/src/tools/docs/insertTableWithData.ts
@@ -145,7 +145,8 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab)',
+            suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
+            fields: 'tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex))))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/docs/insertText.ts
+++ b/src/tools/docs/insertText.ts
@@ -38,7 +38,8 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
+            suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
+            fields: 'tabs(tabProperties(tabId))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/docs/modifyText.ts
+++ b/src/tools/docs/modifyText.ts
@@ -126,7 +126,8 @@ export function register(server: FastMCP) {
           const docInfo = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab)',
+            suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
+            fields: 'tabs(tabProperties(tabId))',
           });
           const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
           if (!targetTab) {

--- a/src/tools/utils/appendMarkdownToGoogleDoc.ts
+++ b/src/tools/utils/appendMarkdownToGoogleDoc.ts
@@ -43,8 +43,9 @@ export function register(server: FastMCP) {
         const doc = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: !!args.tabId,
+          suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
           fields: args.tabId
-            ? 'tabs(tabProperties,documentTab(body(content(endIndex))))'
+            ? 'tabs(tabProperties(tabId),documentTab(body(content(endIndex))))'
             : 'body(content(endIndex))',
         });
 

--- a/src/tools/utils/replaceDocumentWithMarkdown.ts
+++ b/src/tools/utils/replaceDocumentWithMarkdown.ts
@@ -47,8 +47,9 @@ export function register(server: FastMCP) {
         const doc = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: !!args.tabId,
+          suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
           fields: args.tabId
-            ? 'tabs(tabProperties,documentTab(body(content(startIndex,endIndex))))'
+            ? 'tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex))))'
             : 'body(content(startIndex,endIndex))',
         });
 
@@ -113,8 +114,9 @@ export function register(server: FastMCP) {
           const docAfterDelete = await docs.documents.get({
             documentId: args.documentId,
             includeTabsContent: !!args.tabId,
+            suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
             fields: args.tabId
-              ? 'tabs(tabProperties,documentTab(body(content(startIndex,endIndex))))'
+              ? 'tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex))))'
               : 'body(content(startIndex,endIndex))',
           });
 


### PR DESCRIPTION
## Problem

All write tools that operate on document tabs call `documents.get` before mutating content (to verify tab existence or fetch the current end index). Those calls used broad field masks — `tabs(tabProperties,documentTab)` or `tabs(tabProperties,documentTab(body(...)))` — which cause the Google Docs API to return suggestion/comment fields by default.

On documents that have existing comments or suggestions, this triggers:

```
Field mask cannot retrieve comment-specific fields when include_comments is false
```

The error surfaces on every tab write operation (`appendText`, `appendMarkdown`, `replaceDocumentWithMarkdown`, `insertText`, `insertTableWithData`, `modifyText`) for any document that has ever had a comment added.

## Fix

Two changes applied to every affected `documents.get` call:

1. Add `suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS'` — tells the API not to expand suggestion/comment fields.
2. Narrow the field mask to only what each call actually needs:
   - Tab-existence checks: `tabs(tabProperties(tabId))`
   - End-index fetches: `tabs(tabProperties(tabId),documentTab(body(content(endIndex))))`
   - Start+end-index fetches: `tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex))))`

## Files changed

| File | Change |
|------|--------|
| `src/tools/docs/appendToGoogleDoc.ts` | `suggestionsViewMode` + narrow field mask |
| `src/tools/utils/appendMarkdownToGoogleDoc.ts` | `suggestionsViewMode` + narrow field mask |
| `src/tools/utils/replaceDocumentWithMarkdown.ts` | Two `documents.get` calls fixed |
| `src/tools/docs/insertText.ts` | `suggestionsViewMode` + narrow to `tabProperties(tabId)` only |
| `src/tools/docs/insertTableWithData.ts` | `suggestionsViewMode` + narrow field mask |
| `src/tools/docs/modifyText.ts` | `suggestionsViewMode` + narrow to `tabProperties(tabId)` only |

## How to reproduce

1. Open any Google Doc that has at least one comment.
2. Use the MCP server to call `appendText`, `appendMarkdown`, or any other write tool with a `tabId` parameter.
3. Without this fix: `Error: Field mask cannot retrieve comment-specific fields when include_comments is false`.
4. With this fix: the call succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)