### PR TITLE
fix(sheets): escape list query text

### DIFF
--- a/src/tools/sheets/listGoogleSheets.test.ts
+++ b/src/tools/sheets/listGoogleSheets.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { register } from './listGoogleSheets.js';
+
+const mockList = vi.fn();
+
+vi.mock('../../clients.js', () => ({
+  getDriveClient: vi.fn(async () => ({
+    files: {
+      list: mockList,
+    },
+  })),
+}));
+
+describe('listGoogleSheets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockList.mockResolvedValue({ data: { files: [] } });
+  });
+
+  it('escapes search text before interpolating it into the Drive query', async () => {
+    const tools: any[] = [];
+    register({ addTool: (tool: any) => tools.push(tool) } as any);
+
+    await tools[0].execute(
+      {
+        maxResults: 20,
+        query: "owner's \\ budget",
+        orderBy: 'modifiedTime',
+      },
+      { log: { info: vi.fn(), error: vi.fn() } }
+    );
+
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q:
+          "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false and " +
+          "(name contains 'owner\\'s \\\\ budget' or fullText contains 'owner\\'s \\\\ budget')",
+      })
+    );
+  });
+});

--- a/src/tools/sheets/listGoogleSheets.ts
+++ b/src/tools/sheets/listGoogleSheets.ts
@@ -2,6 +2,7 @@ import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getDriveClient } from '../../clients.js';
+import { escapeDriveQuery } from '../../driveQueryUtils.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -36,7 +37,8 @@ export function register(server: FastMCP) {
         // Build the query string for Google Drive API
         let queryString = "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false";
         if (args.query) {
-          queryString += ` and (name contains '${args.query}' or fullText contains '${args.query}')`;
+          const escapedQuery = escapeDriveQuery(args.query);
+          queryString += ` and (name contains '${escapedQuery}' or fullText contains '${escapedQuery}')`;
         }
 
         const response = await drive.files.list({


### PR DESCRIPTION
Closes #100.

## Summary
- escape user-provided sheet search text before inserting it into the Drive query
- add a regression test covering apostrophes and backslashes in the query text

## Testing
- npm ci --registry=https://registry.npmjs.org --no-audit --no-fund --loglevel=warn
- npm test -- src/tools/sheets/listGoogleSheets.test.ts
- npm run build