### PR TITLE
fix(docs): narrow tab field masks

### DIFF
--- a/src/tools/docs/appendToGoogleDoc.ts
+++ b/src/tools/docs/appendToGoogleDoc.ts
@@ -5,6 +5,7 @@ import { docs_v1 } from 'googleapis';
 import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter, NotImplementedError } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { TAB_BODY_END_INDEX_FIELDS } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -43,7 +44,7 @@ export function register(server: FastMCP) {
           includeTabsContent: needsTabsContent,
           suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
           fields: needsTabsContent
-            ? 'tabs(tabProperties(tabId),documentTab(body(content(endIndex))))'
+            ? TAB_BODY_END_INDEX_FIELDS
             : 'body(content(endIndex)),documentStyle(pageSize)',
         });
 

--- a/src/tools/docs/listDocumentTabs.ts
+++ b/src/tools/docs/listDocumentTabs.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
+import { TAB_LIST_FIELDS, TAB_LIST_WITH_CONTENT_FIELDS } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -27,9 +28,7 @@ export function register(server: FastMCP) {
           documentId: args.documentId,
           includeTabsContent: true,
           // Only get essential fields for tab listing
-          fields: args.includeContent
-            ? 'title,tabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties))),documentTab(body(content(endIndex))))' // Explicit fields to avoid comment-field validation
-            : 'title,tabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties,childTabs(tabProperties))))', // Recursive structure only
+          fields: args.includeContent ? TAB_LIST_WITH_CONTENT_FIELDS : TAB_LIST_FIELDS,
         });
 
         const docTitle = res.data.title || 'Untitled Document';

--- a/src/tools/docs/tabFieldMasks.test.ts
+++ b/src/tools/docs/tabFieldMasks.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { TAB_FIELD_MASKS } from './tabFieldMasks.js';
+
+describe('Google Docs tab field masks', () => {
+  it('uses explicit tab properties instead of broad tab expansions', () => {
+    for (const mask of Object.values(TAB_FIELD_MASKS)) {
+      expect(mask).not.toContain('tabs)');
+      expect(mask).not.toContain('tabProperties,');
+      expect(mask).not.toContain('childTabs(tabProperties,');
+      expect(mask).toContain('tabProperties(tabId');
+    }
+  });
+});

--- a/src/tools/docs/tabFieldMasks.ts
+++ b/src/tools/docs/tabFieldMasks.ts
@@ -1,0 +1,17 @@
+export const TAB_ID_PROPERTIES = 'tabProperties(tabId)';
+export const TAB_LIST_PROPERTIES = 'tabProperties(tabId,title,index,parentTabId)';
+
+export const TAB_BODY_RANGE_FIELDS = `tabs(${TAB_ID_PROPERTIES},documentTab(body(content(startIndex,endIndex))))`;
+export const TAB_BODY_END_INDEX_FIELDS = `tabs(${TAB_ID_PROPERTIES},documentTab(body(content(endIndex))))`;
+
+const TAB_LIST_CHILD_FIELDS = `childTabs(${TAB_LIST_PROPERTIES},childTabs(${TAB_LIST_PROPERTIES},childTabs(${TAB_LIST_PROPERTIES})))`;
+
+export const TAB_LIST_FIELDS = `title,tabs(${TAB_LIST_PROPERTIES},${TAB_LIST_CHILD_FIELDS})`;
+export const TAB_LIST_WITH_CONTENT_FIELDS = `title,tabs(${TAB_LIST_PROPERTIES},${TAB_LIST_CHILD_FIELDS},documentTab(body(content(endIndex))))`;
+
+export const TAB_FIELD_MASKS = {
+  TAB_BODY_RANGE_FIELDS,
+  TAB_BODY_END_INDEX_FIELDS,
+  TAB_LIST_FIELDS,
+  TAB_LIST_WITH_CONTENT_FIELDS,
+} as const;

--- a/src/tools/utils/appendMarkdownToGoogleDoc.ts
+++ b/src/tools/utils/appendMarkdownToGoogleDoc.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter, MarkdownConversionError } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { insertMarkdown, formatInsertResult } from '../../markdown-transformer/index.js';
+import { TAB_BODY_END_INDEX_FIELDS } from '../docs/tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -44,9 +45,7 @@ export function register(server: FastMCP) {
           documentId: args.documentId,
           includeTabsContent: !!args.tabId,
           suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
-          fields: args.tabId
-            ? 'tabs(tabProperties(tabId),documentTab(body(content(endIndex))))'
-            : 'body(content(endIndex))',
+          fields: args.tabId ? TAB_BODY_END_INDEX_FIELDS : 'body(content(endIndex))',
         });
 
         let bodyContent: any;

--- a/src/tools/utils/replaceDocumentWithMarkdown.ts
+++ b/src/tools/utils/replaceDocumentWithMarkdown.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter, MarkdownConversionError } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { insertMarkdown, formatInsertResult } from '../../markdown-transformer/index.js';
+import { TAB_BODY_RANGE_FIELDS } from '../docs/tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -48,9 +49,7 @@ export function register(server: FastMCP) {
           documentId: args.documentId,
           includeTabsContent: !!args.tabId,
           suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
-          fields: args.tabId
-            ? 'tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex))))'
-            : 'body(content(startIndex,endIndex))',
+          fields: args.tabId ? TAB_BODY_RANGE_FIELDS : 'body(content(startIndex,endIndex))',
         });
 
         // 2. Calculate replacement range
@@ -115,9 +114,7 @@ export function register(server: FastMCP) {
             documentId: args.documentId,
             includeTabsContent: !!args.tabId,
             suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
-            fields: args.tabId
-              ? 'tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex))))'
-              : 'body(content(startIndex,endIndex))',
+            fields: args.tabId ? TAB_BODY_RANGE_FIELDS : 'body(content(startIndex,endIndex))',
           });
 
           let survivorContent: any;


### PR DESCRIPTION
Fixes #117.

## Summary
- replace broad tab field mask fragments in the affected tab-aware tools with shared explicit masks
- keep `replaceDocumentWithMarkdown`, `appendMarkdown`, `appendText`, and `listTabs` away from implicit comment-related tab/document fields
- add a regression test for the tab field mask constants

## Tests
- `npm test -- src/tools/docs/tabFieldMasks.test.ts`
- `npm run build`