### PR TITLE
fix(tools): reject unknown parameter keys

### DIFF
--- a/src/tools/calendar/createEvent.ts
+++ b/src/tools/calendar/createEvent.ts
@@ -10,7 +10,7 @@ export function register(server: FastMCP) {
     name: 'createEvent',
     description:
       'Creates a new event on a Google Calendar. Supports timed events (start/end with dateTime) and all-day events (start/end with date). Set sendUpdates to email invitations to attendees.',
-    parameters: z.object({
+    parameters: z.strictObject({
       calendarId: z
         .string()
         .optional()
@@ -25,7 +25,7 @@ export function register(server: FastMCP) {
       ),
       attendees: z
         .array(
-          z.object({
+          z.strictObject({
             email: z.string().describe('Attendee email address.'),
             optional: z.boolean().optional().describe('Mark attendee as optional.'),
           })

--- a/src/tools/calendar/deleteEvent.ts
+++ b/src/tools/calendar/deleteEvent.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'deleteEvent',
     description:
       'Deletes an event from a Google Calendar. This is permanent — the event is removed, not trashed. Use sendUpdates to email cancellations to attendees.',
-    parameters: z.object({
+    parameters: z.strictObject({
       calendarId: z
         .string()
         .optional()

--- a/src/tools/calendar/listEvents.ts
+++ b/src/tools/calendar/listEvents.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'listEvents',
     description:
       "Lists or searches Google Calendar events. Defaults to the user's primary calendar starting now. Use timeMin/timeMax (RFC3339 timestamps) to bound the window, q for free-text search, and maxResults to cap the count. Returns event IDs needed for updateEvent and deleteEvent.",
-    parameters: z.object({
+    parameters: z.strictObject({
       calendarId: z
         .string()
         .optional()

--- a/src/tools/calendar/quickAddEvent.ts
+++ b/src/tools/calendar/quickAddEvent.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'quickAddEvent',
     description:
       'Creates a calendar event from a natural-language string using Google Calendar\'s quick-add parser. Examples: "Lunch with Sarah tomorrow at 12pm", "Dentist appointment next Tuesday 3-4pm", "Team standup every weekday 9am". Faster than createEvent when you don\'t need attendees, descriptions, or precise control over fields.',
-    parameters: z.object({
+    parameters: z.strictObject({
       calendarId: z
         .string()
         .optional()

--- a/src/tools/calendar/updateEvent.ts
+++ b/src/tools/calendar/updateEvent.ts
@@ -10,7 +10,7 @@ export function register(server: FastMCP) {
     name: 'updateEvent',
     description:
       'Updates an existing Google Calendar event with PATCH semantics — only the fields you provide are changed; everything else stays the same. Common uses: reschedule (set start+end), retitle (set summary), add/remove attendees (set attendees array which fully replaces).',
-    parameters: z.object({
+    parameters: z.strictObject({
       calendarId: z
         .string()
         .optional()
@@ -24,7 +24,7 @@ export function register(server: FastMCP) {
       end: eventDateTimeSchema.optional().describe('New end time.'),
       attendees: z
         .array(
-          z.object({
+          z.strictObject({
             email: z.string(),
             optional: z.boolean().optional(),
           })

--- a/src/tools/docs/formatting/updateTableBorders.ts
+++ b/src/tools/docs/formatting/updateTableBorders.ts
@@ -6,7 +6,7 @@ import { DocumentIdParameter, validateHexColor, hexToRgbColor } from '../../../t
 import { getTableById } from '../structureHelpers.js';
 import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
 
-const BorderSideSchema = z.object({
+const BorderSideSchema = z.strictObject({
   color: z
     .string()
     .refine(validateHexColor, { message: 'Invalid hex color format (e.g., #000000).' })

--- a/src/tools/docs/modifyText.ts
+++ b/src/tools/docs/modifyText.ts
@@ -17,7 +17,7 @@ const RangeTarget = z
     path: ['endIndex'],
   });
 
-const InsertionTarget = z.object({
+const InsertionTarget = z.strictObject({
   insertionIndex: z.number().int().min(1).describe('Index to insert at (1-based).'),
 });
 

--- a/src/tools/drive/copyFile.ts
+++ b/src/tools/drive/copyFile.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'copyFile',
     description:
       "Creates a copy of a file or document in Google Drive. Returns the new copy's ID and URL.",
-    parameters: z.object({
+    parameters: z.strictObject({
       fileId: z
         .string()
         .describe('The file or folder ID from a Google Drive URL or a previous tool result.'),

--- a/src/tools/drive/createDocument.ts
+++ b/src/tools/drive/createDocument.ts
@@ -10,7 +10,7 @@ export function register(server: FastMCP) {
     name: 'createDocument',
     description:
       'Creates a new empty Google Document. Optionally places it in a specific folder and adds initial text content.',
-    parameters: z.object({
+    parameters: z.strictObject({
       title: z.string().min(1).describe('Title for the new document.'),
       parentFolderId: z
         .string()

--- a/src/tools/drive/createFolder.ts
+++ b/src/tools/drive/createFolder.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'createFolder',
     description:
       'Creates a new folder in Google Drive. Optionally places it inside an existing parent folder.',
-    parameters: z.object({
+    parameters: z.strictObject({
       name: z.string().min(1).describe('Name for the new folder.'),
       parentFolderId: z
         .string()

--- a/src/tools/drive/createFromTemplate.ts
+++ b/src/tools/drive/createFromTemplate.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'createDocumentFromTemplate',
     description:
       'Creates a new document by copying an existing template and optionally replacing placeholder text. Provide key-value pairs in the replacements parameter to substitute template variables.',
-    parameters: z.object({
+    parameters: z.strictObject({
       templateId: z.string().describe('ID of the template document to copy from.'),
       newTitle: z.string().min(1).describe('Title for the new document.'),
       parentFolderId: z

--- a/src/tools/drive/deleteFile.ts
+++ b/src/tools/drive/deleteFile.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'deleteFile',
     description:
       'Moves a file or folder to the trash, or permanently deletes it. Set permanent=true for irreversible deletion.',
-    parameters: z.object({
+    parameters: z.strictObject({
       fileId: z
         .string()
         .describe('The file or folder ID from a Google Drive URL or a previous tool result.'),

--- a/src/tools/drive/downloadFile.ts
+++ b/src/tools/drive/downloadFile.ts
@@ -55,7 +55,7 @@ function ensureWithinCwd(filePath: string): string {
   return resolved;
 }
 
-const DownloadFileParameters = z.object({
+const DownloadFileParameters = z.strictObject({
   fileId: z.string().describe('The file ID from a Google Drive URL or previous tool result.'),
   savePath: z
     .string()

--- a/src/tools/drive/getFolderInfo.ts
+++ b/src/tools/drive/getFolderInfo.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'getFolderInfo',
     description:
       'Gets metadata about a Drive folder including its name, owner, sharing status, and parent folder.',
-    parameters: z.object({
+    parameters: z.strictObject({
       folderId: z.string().describe('ID of the folder to get information about.'),
     }),
     execute: async (args, { log }) => {

--- a/src/tools/drive/listDriveFiles.ts
+++ b/src/tools/drive/listDriveFiles.ts
@@ -27,7 +27,7 @@ export function register(server: FastMCP) {
       '(Sheets, PDFs, images, folders, etc.) and supports sort direction and size-based ordering. ' +
       'Use mimeType shortcuts: "document", "spreadsheet", "presentation", "folder", "form", "pdf", "zip" ' +
       'or pass any full MIME type string.',
-    parameters: z.object({
+    parameters: z.strictObject({
       maxResults: z
         .number()
         .int()

--- a/src/tools/drive/listFolderContents.ts
+++ b/src/tools/drive/listFolderContents.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'listFolderContents',
     description:
       "Lists files and subfolders within a Drive folder. Use folderId='root' to browse the top-level of the Drive.",
-    parameters: z.object({
+    parameters: z.strictObject({
       folderId: z
         .string()
         .describe('ID of the folder to list contents of. Use "root" for the root Drive folder.'),

--- a/src/tools/drive/listGoogleDocs.ts
+++ b/src/tools/drive/listGoogleDocs.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'listDocuments',
     description:
       'Lists Google Documents in your Drive, optionally filtered by name or content. Use modifiedAfter to find recently changed documents.',
-    parameters: z.object({
+    parameters: z.strictObject({
       maxResults: z
         .number()
         .int()

--- a/src/tools/drive/moveFile.ts
+++ b/src/tools/drive/moveFile.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'moveFile',
     description:
       'Moves a file or folder to a different Drive folder. By default adds the new parent while keeping existing parents; set removeFromAllParents=true for a true move.',
-    parameters: z.object({
+    parameters: z.strictObject({
       fileId: z
         .string()
         .describe('The file or folder ID from a Google Drive URL or a previous tool result.'),

--- a/src/tools/drive/renameFile.ts
+++ b/src/tools/drive/renameFile.ts
@@ -7,7 +7,7 @@ export function register(server: FastMCP) {
   server.addTool({
     name: 'renameFile',
     description: 'Renames a file or folder in Google Drive. Returns the updated file info.',
-    parameters: z.object({
+    parameters: z.strictObject({
       fileId: z
         .string()
         .describe('The file or folder ID from a Google Drive URL or a previous tool result.'),

--- a/src/tools/drive/searchDriveFiles.ts
+++ b/src/tools/drive/searchDriveFiles.ts
@@ -26,7 +26,7 @@ export function register(server: FastMCP) {
       'Unlike searchDocuments (which only searches Google Docs), this tool finds Sheets, PDFs, ' +
       'presentations, folders, and any other Drive file. Supports filtering by MIME type, ' +
       'scoping to a specific folder subtree, controllable sort order, and pagination via pageToken.',
-    parameters: z.object({
+    parameters: z.strictObject({
       query: z.string().min(1).describe('Search term to find in file names or content.'),
       searchIn: z
         .enum(['name', 'content', 'both'])

--- a/src/tools/drive/searchGoogleDocs.ts
+++ b/src/tools/drive/searchGoogleDocs.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'searchDocuments',
     description:
       'Searches for documents by name, content, or both. Use listDocuments for browsing and this tool for targeted queries.',
-    parameters: z.object({
+    parameters: z.strictObject({
       query: z.string().min(1).describe('Search term to find in document names or content.'),
       searchIn: z
         .enum(['name', 'content', 'both'])

--- a/src/tools/gmail/createDraft.ts
+++ b/src/tools/gmail/createDraft.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'createDraft',
     description:
       'Creates a Gmail draft (does NOT send). Use this for AI-composed emails that the user should review before sending. The draft appears in the Gmail Drafts folder and can be sent later with sendDraft, edited with updateDraft, or deleted with deleteDraft. Supports threading via replyToMessageId.',
-    parameters: z.object({
+    parameters: z.strictObject({
       to: z
         .union([z.string(), z.array(z.string()).min(1)])
         .describe('Recipient email address, or an array of recipient email addresses.'),

--- a/src/tools/gmail/deleteDraft.ts
+++ b/src/tools/gmail/deleteDraft.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'deleteDraft',
     description:
       'Permanently deletes a Gmail draft. This is irreversible — the draft is removed entirely, not moved to Trash. Use when an AI-composed draft was rejected or replaced.',
-    parameters: z.object({
+    parameters: z.strictObject({
       draftId: z
         .string()
         .describe('The Gmail draft ID to delete (from createDraft or listDrafts).'),

--- a/src/tools/gmail/getDraft.ts
+++ b/src/tools/gmail/getDraft.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'getDraft',
     description:
       'Fetches a single Gmail draft by ID with full headers and body. Use listDrafts to discover draft IDs.',
-    parameters: z.object({
+    parameters: z.strictObject({
       draftId: z.string().describe('The Gmail draft ID, typically from listDrafts results.'),
     }),
     execute: async (args, { log }) => {

--- a/src/tools/gmail/getMessage.ts
+++ b/src/tools/gmail/getMessage.ts
@@ -35,7 +35,7 @@ export function register(server: FastMCP) {
     name: 'getMessage',
     description:
       'Fetches a single Gmail message by ID with headers, decoded plain-text body, HTML body, and a list of attachments (metadata only). Use listMessages to discover message IDs.',
-    parameters: z.object({
+    parameters: z.strictObject({
       messageId: z.string().describe('The Gmail message ID, typically from listMessages results.'),
       format: z
         .enum(['full', 'metadata', 'minimal'])

--- a/src/tools/gmail/listDrafts.ts
+++ b/src/tools/gmail/listDrafts.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'listDrafts',
     description:
       'Lists Gmail drafts for the authenticated user. Returns draft IDs along with the recipient, subject, snippet, and date for each. Use sendDraft, updateDraft, or deleteDraft to act on a returned draft.',
-    parameters: z.object({
+    parameters: z.strictObject({
       maxResults: z
         .number()
         .int()

--- a/src/tools/gmail/listLabels.ts
+++ b/src/tools/gmail/listLabels.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'listLabels',
     description:
       'Lists all Gmail labels for the authenticated user, including system labels (INBOX, SENT, STARRED, UNREAD, etc.) and custom user-created labels. Use the returned IDs with modifyMessageLabels or listMessages labelIds filter.',
-    parameters: z.object({}),
+    parameters: z.strictObject({}),
     execute: async (_args, { log }) => {
       const gmail = await getGmailClient();
       log.info('Listing Gmail labels');

--- a/src/tools/gmail/listMessages.ts
+++ b/src/tools/gmail/listMessages.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'listMessages',
     description:
       'Lists Gmail messages for the authenticated user. Supports the full Gmail search syntax via the q parameter (e.g. "is:unread", "from:alice@example.com", "subject:invoice newer_than:7d"). Returns message IDs with sender, subject, date, and snippet for each result.',
-    parameters: z.object({
+    parameters: z.strictObject({
       maxResults: z
         .number()
         .int()

--- a/src/tools/gmail/sendDraft.ts
+++ b/src/tools/gmail/sendDraft.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'sendDraft',
     description:
       'Sends an existing Gmail draft. After sending, the draft is removed and the message appears in Sent. This is the second half of the compose-review-send flow that pairs with createDraft.',
-    parameters: z.object({
+    parameters: z.strictObject({
       draftId: z.string().describe('The Gmail draft ID to send (from createDraft or listDrafts).'),
     }),
     execute: async (args, { log }) => {

--- a/src/tools/gmail/sendEmail.ts
+++ b/src/tools/gmail/sendEmail.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'sendEmail',
     description:
       'Sends a plain-text email from the authenticated Gmail account. Supports cc/bcc and optional threading by passing replyToMessageId (which copies threadId and sets In-Reply-To/References so the reply lands in the same thread).',
-    parameters: z.object({
+    parameters: z.strictObject({
       to: z
         .union([z.string(), z.array(z.string()).min(1)])
         .describe('Recipient email address, or an array of recipient email addresses.'),

--- a/src/tools/gmail/trashMessage.ts
+++ b/src/tools/gmail/trashMessage.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'trashMessage',
     description:
       'Moves a Gmail message to Trash. This is the same as clicking Delete in the Gmail UI — reversible from the Trash folder for 30 days. Not a permanent delete.',
-    parameters: z.object({
+    parameters: z.strictObject({
       messageId: z.string().describe('The Gmail message ID to move to Trash.'),
     }),
     execute: async (args, { log }) => {

--- a/src/tools/gmail/triageInbox.ts
+++ b/src/tools/gmail/triageInbox.ts
@@ -31,7 +31,7 @@ export function register(server: FastMCP) {
     name: 'triageInbox',
     description:
       "Composite tool: fetches the user's most recent unread Gmail messages with full content and heuristic categorization in a single call. Returns headers, body excerpts, labels, plus per-message signals (newsletter, meeting reference, contains question, action requested) AND aggregate stats (total unread, top senders, breakdown by category). Designed for AI inbox triage workflows — use the returned data to decide which messages need a reply, can be archived, or warrant a draft response. Pairs naturally with createDraft, modifyMessageLabels, and trashMessage.",
-    parameters: z.object({
+    parameters: z.strictObject({
       maxResults: z
         .number()
         .int()

--- a/src/tools/gmail/updateDraft.ts
+++ b/src/tools/gmail/updateDraft.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'updateDraft',
     description:
       'Replaces the contents of an existing Gmail draft. The new contents fully overwrite the old draft (this is a full replace, not a patch). Use this when iterating on an AI-composed draft before sending.',
-    parameters: z.object({
+    parameters: z.strictObject({
       draftId: z.string().describe('The Gmail draft ID to update.'),
       to: z
         .union([z.string(), z.array(z.string()).min(1)])

--- a/src/tools/sheets/addSpreadsheetSheet.ts
+++ b/src/tools/sheets/addSpreadsheetSheet.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'addSheet',
     description:
       "Adds a new sheet (tab) to an existing spreadsheet. Returns the new sheet's title and ID.",
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/appendSpreadsheetRows.ts
+++ b/src/tools/sheets/appendSpreadsheetRows.ts
@@ -10,7 +10,7 @@ export function register(server: FastMCP) {
     name: 'appendRows',
     description:
       'Appends rows to the end of a sheet. Data is added after the last row with content in the specified range.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/appendTableRows.ts
+++ b/src/tools/sheets/appendTableRows.ts
@@ -10,7 +10,7 @@ export function register(server: FastMCP) {
     name: 'appendTableRows',
     description:
       'Appends rows to the end of a table using table-aware insertion. This method respects footers and automatically inserts rows before the footer if one exists.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/autoResizeColumns.ts
+++ b/src/tools/sheets/autoResizeColumns.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'autoResizeColumns',
     description:
       'Auto-resizes columns in a spreadsheet to fit their content. Optionally restrict to a column range (e.g., "A:S"); defaults to all columns.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/batchWrite.ts
+++ b/src/tools/sheets/batchWrite.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'batchWrite',
     description:
       'Writes data to multiple ranges in a single API call. More efficient than multiple separate writeSpreadsheet calls when updating several ranges at once.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(
@@ -17,7 +17,7 @@ export function register(server: FastMCP) {
         ),
       data: z
         .array(
-          z.object({
+          z.strictObject({
             range: z.string().describe('A1 notation range (e.g., "Sheet1!A1:B2").'),
             values: z
               .array(z.array(SpreadsheetCellValueSchema))

--- a/src/tools/sheets/clearSpreadsheetRange.ts
+++ b/src/tools/sheets/clearSpreadsheetRange.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'clearRange',
     description:
       'Clears all cell values in a range without deleting the cells themselves. Formatting is preserved.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/comments/deleteSheetsComment.ts
+++ b/src/tools/sheets/comments/deleteSheetsComment.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
   server.addTool({
     name: 'deleteSheetsComment',
     description: 'Permanently deletes a comment and all its replies from a Google Spreadsheet.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/comments/getSheetsComment.ts
+++ b/src/tools/sheets/comments/getSheetsComment.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'getSheetsComment',
     description:
       'Gets a specific comment and its full reply thread from a Google Spreadsheet. Use listSheetsComments first to find the comment ID.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/comments/listSheetsComments.ts
+++ b/src/tools/sheets/comments/listSheetsComments.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'listSheetsComments',
     description:
       'Lists all comments in a Google Spreadsheet. Filter by sheet name, specific row(s), specific cell, or a cell range. Returns comment IDs needed for getSheetsComment, replyToSheetsComment, resolveSheetsComment, or deleteSheetsComment.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/comments/replyToSheetsComment.ts
+++ b/src/tools/sheets/comments/replyToSheetsComment.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'replyToSheetsComment',
     description:
       'Adds a reply to an existing comment thread in a Google Spreadsheet. Use listSheetsComments or getSheetsComment to find the comment ID.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/comments/resolveSheetsComment.ts
+++ b/src/tools/sheets/comments/resolveSheetsComment.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'resolveSheetsComment',
     description:
       'Marks a comment as resolved in a Google Spreadsheet. Note: resolved status may not persist in the Sheets UI due to a Drive API limitation.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/copyFormatting.ts
+++ b/src/tools/sheets/copyFormatting.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'copyFormatting',
     description:
       'Copies formatting (not values) from a source range to a destination range within the same spreadsheet. Copies bold, colors, borders, number formats, etc.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/copySheetTo.ts
+++ b/src/tools/sheets/copySheetTo.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'copySheetTo',
     description:
       'Copies a sheet (tab) from one spreadsheet to another spreadsheet. Use getSpreadsheetInfo to find the numeric sheet ID. The copied sheet will be appended to the destination spreadsheet.',
-    parameters: z.object({
+    parameters: z.strictObject({
       sourceSpreadsheetId: z.string().describe('The spreadsheet ID of the source file.'),
       sheetId: z
         .number()

--- a/src/tools/sheets/createSpreadsheet.ts
+++ b/src/tools/sheets/createSpreadsheet.ts
@@ -11,7 +11,7 @@ export function register(server: FastMCP) {
     name: 'createSpreadsheet',
     description:
       'Creates a new spreadsheet. Optionally places it in a specific folder and populates it with initial data.',
-    parameters: z.object({
+    parameters: z.strictObject({
       title: z.string().min(1).describe('Title for the new spreadsheet.'),
       parentFolderId: z
         .string()

--- a/src/tools/sheets/createTable.ts
+++ b/src/tools/sheets/createTable.ts
@@ -40,7 +40,7 @@ export function register(server: FastMCP) {
           ),
         columns: z
           .array(
-            z.object({
+            z.strictObject({
               columnName: z.string().min(1).describe('Display name for the column header.'),
               columnType: ColumnTypeSchema.optional().describe(
                 'Data type for the column (default: TEXT).'

--- a/src/tools/sheets/deleteChart.ts
+++ b/src/tools/sheets/deleteChart.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     description:
       'Deletes a chart from a Google Spreadsheet by chart ID. ' +
       'The chart ID is returned when a chart is created with insertChart.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/deleteConditionalFormatting.ts
+++ b/src/tools/sheets/deleteConditionalFormatting.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'deleteConditionalFormatting',
     description:
       'Deletes one or more conditional formatting rules from a sheet by their index. Use getConditionalFormatting to list existing rules and their indices.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/deleteSheet.ts
+++ b/src/tools/sheets/deleteSheet.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'deleteSheet',
     description:
       'Deletes a sheet (tab) from a spreadsheet. Use getSpreadsheetInfo to find the numeric sheet ID.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/deleteTable.ts
+++ b/src/tools/sheets/deleteTable.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'deleteTable',
     description:
       'Deletes a table from a spreadsheet. By default, only removes the table object and formatting while keeping the cell data. Optionally clears the data as well.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/duplicateSheet.ts
+++ b/src/tools/sheets/duplicateSheet.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'duplicateSheet',
     description:
       'Duplicates a sheet (tab) within a spreadsheet, copying all values, formulas, formatting, validations, and conditional formatting. Use getSpreadsheetInfo to find the numeric sheet ID.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/getConditionalFormatting.ts
+++ b/src/tools/sheets/getConditionalFormatting.ts
@@ -27,7 +27,7 @@ export function register(server: FastMCP) {
     name: 'getConditionalFormatting',
     description:
       'Lists all conditional formatting rules for a sheet as JSON. Each rule includes its index (needed for deleteConditionalFormatting), kind (BOOLEAN or GRADIENT), ranges, condition type/values, and applied formats (colors, bold, italic).',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/getSpreadsheetInfo.ts
+++ b/src/tools/sheets/getSpreadsheetInfo.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'getSpreadsheetInfo',
     description:
       'Gets metadata about a spreadsheet including its title, URL, and a list of all sheets with their dimensions.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/getTable.ts
+++ b/src/tools/sheets/getTable.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'getTable',
     description:
       'Gets detailed information about a specific table including its columns, range, and properties. Use the table name or ID returned by listTables.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/groupRows.ts
+++ b/src/tools/sheets/groupRows.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'groupRows',
     description:
       'Creates collapsible row groups in a Google Sheet using the Sheets API addDimensionGroup request. Each group specifies a range of rows (1-based, inclusive) to collapse.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(
@@ -21,7 +21,7 @@ export function register(server: FastMCP) {
         .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
       groups: z
         .array(
-          z.object({
+          z.strictObject({
             startRowIndex: z
               .number()
               .int()

--- a/src/tools/sheets/insertChart.ts
+++ b/src/tools/sheets/insertChart.ts
@@ -11,7 +11,7 @@ export function register(server: FastMCP) {
       'Inserts a chart into a Google Sheet. Supports bar, column, line, area, scatter, pie, donut, and treemap (hierarchical) chart types. ' +
       'For treemap charts, the data must have a label column and a parent label column (use empty string for root nodes) plus a numeric size column. ' +
       'Chart is placed as an overlay at the specified anchor cell.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/listGoogleSheets.ts
+++ b/src/tools/sheets/listGoogleSheets.ts
@@ -7,7 +7,7 @@ export function register(server: FastMCP) {
   server.addTool({
     name: 'listSpreadsheets',
     description: 'Lists spreadsheets in your Drive, optionally filtered by name or content.',
-    parameters: z.object({
+    parameters: z.strictObject({
       maxResults: z
         .number()
         .int()

--- a/src/tools/sheets/listTables.ts
+++ b/src/tools/sheets/listTables.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'listTables',
     description:
       'Lists all tables in a spreadsheet or specific sheet. Use this to discover table names and IDs before performing table operations.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/protectRange.ts
+++ b/src/tools/sheets/protectRange.ts
@@ -10,7 +10,7 @@ export function register(server: FastMCP) {
     name: 'protectRange',
     description:
       "Locks (protects) a range or an entire sheet to prevent accidental edits. Optionally specify a description. The protection applies to the authenticated user's account.",
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/readCellFormat.ts
+++ b/src/tools/sheets/readCellFormat.ts
@@ -91,7 +91,7 @@ export function register(server: FastMCP) {
     name: 'readCellFormat',
     description:
       'Reads the formatting/style of cells in a given range. Returns formatting details like bold, italic, fontSize, fontFamily, colors, alignment, borders, and number format per cell.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/readSpreadsheet.ts
+++ b/src/tools/sheets/readSpreadsheet.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'readSpreadsheet',
     description:
       'Reads data from a range in a spreadsheet. Returns rows as arrays. Use A1 notation for the range (e.g., "Sheet1!A1:C10").',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/renameSheet.ts
+++ b/src/tools/sheets/renameSheet.ts
@@ -8,7 +8,7 @@ export function register(server: FastMCP) {
     name: 'renameSheet',
     description:
       'Renames a sheet (tab) in a spreadsheet. Use getSpreadsheetInfo to find the numeric sheet ID.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/setColumnWidths.ts
+++ b/src/tools/sheets/setColumnWidths.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'setColumnWidths',
     description:
       'Sets the width (in pixels) of one or more columns in a spreadsheet. Accepts multiple column specs in a single call, each targeting a single column or a contiguous range (e.g., "A", "B:D").',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(
@@ -21,7 +21,7 @@ export function register(server: FastMCP) {
         .describe('Name of the sheet/tab. Defaults to the first sheet if not provided.'),
       columnWidths: z
         .array(
-          z.object({
+          z.strictObject({
             column: z
               .string()
               .describe('Column or column range in A1 notation (e.g., "A", "B:D").'),

--- a/src/tools/sheets/setDropdownValidation.ts
+++ b/src/tools/sheets/setDropdownValidation.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'setDropdownValidation',
     description:
       'Adds or removes a dropdown list on a range of cells. Provide values to create a dropdown restricting input to those options. Omit values to remove dropdown validation from the range.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/ungroupAllRows.ts
+++ b/src/tools/sheets/ungroupAllRows.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'ungroupAllRows',
     description:
       'Removes all row groupings from a sheet by deleting the entire row dimension group. Use before re-running groupRows to prevent duplicate collapse widgets from accumulating across report refreshes.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/updateTableRange.ts
+++ b/src/tools/sheets/updateTableRange.ts
@@ -9,7 +9,7 @@ export function register(server: FastMCP) {
     name: 'updateTableRange',
     description:
       "Modifies a table's dimensions (add/remove rows and columns) by updating its range. The new range must include the original table range.",
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/tools/sheets/writeSpreadsheet.ts
+++ b/src/tools/sheets/writeSpreadsheet.ts
@@ -10,7 +10,7 @@ export function register(server: FastMCP) {
     name: 'writeSpreadsheet',
     description:
       'Writes data to a range in a spreadsheet, overwriting existing values. Use appendRows to add data without overwriting.',
-    parameters: z.object({
+    parameters: z.strictObject({
       spreadsheetId: z
         .string()
         .describe(

--- a/src/types.strict.test.ts
+++ b/src/types.strict.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { DocumentIdParameter } from './types.js';
+
+describe('shared tool parameter schemas', () => {
+  it('rejects unknown top-level keys', () => {
+    const result = DocumentIdParameter.safeParse({
+      documentId: 'doc-123',
+      folderId: 'wrong-key',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.code).toBe('unrecognized_keys');
+      expect(result.error.issues[0]).toMatchObject({ keys: ['folderId'] });
+    }
+  });
+
+  it('keeps strict mode when shared schemas are extended by tools', () => {
+    const extended = DocumentIdParameter.extend({
+      title: z.string(),
+    });
+
+    const result = extended.safeParse({
+      documentId: 'doc-123',
+      title: 'Report',
+      folderId: 'wrong-key',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export function hexToRgbColor(hex: string): docs_v1.Schema$RgbColor | null {
 
 // --- Zod Schema Fragments for Reusability ---
 
-export const DocumentIdParameter = z.object({
+export const DocumentIdParameter = z.strictObject({
   documentId: z
     .string()
     .describe('The document ID — the long string between /d/ and /edit in a Google Docs URL.'),
@@ -72,7 +72,7 @@ export const OptionalRangeParameters = z
     path: ['endIndex'],
   });
 
-export const TextFindParameter = z.object({
+export const TextFindParameter = z.strictObject({
   textToFind: z.string().min(1).describe('The exact text string to locate.'),
   matchInstance: z
     .number()
@@ -184,7 +184,7 @@ export const ApplyParagraphStyleToolParameters = DocumentIdParameter.extend({
     .union([
       RangeParameters, // User provides paragraph start/end (less likely)
       TextFindParameter, // Find text within paragraph to apply style
-      z.object({
+      z.strictObject({
         // Target by specific index within the paragraph
         indexWithinParagraph: z
           .number()


### PR DESCRIPTION
Fixes #106.

## Summary
- convert tool parameter schemas from `z.object` to `z.strictObject` so unknown keys produce validation errors instead of being silently stripped
- strictify shared parameter fragments such as `DocumentIdParameter`, so tools built with `.extend(...)` inherit the behavior
- add a regression test for unknown top-level keys and extended shared schemas

## Tests
- `npm test -- src/types.strict.test.ts`
- `npm run build`