### PR TITLE
fix(sheets): escape Drive query text in listSpreadsheets

### DIFF
--- a/src/tools/sheets/listGoogleSheets.test.ts
+++ b/src/tools/sheets/listGoogleSheets.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getDriveClient } from '../../clients.js';
+import { register } from './listGoogleSheets.js';
+
+vi.mock('../../clients.js', () => ({
+  getDriveClient: vi.fn(),
+}));
+
+const mockGetDriveClient = vi.mocked(getDriveClient);
+const mockLog = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+let toolExecute: (args: any, context: any) => Promise<string>;
+let filesList: ReturnType<typeof vi.fn>;
+
+describe('listGoogleSheets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    filesList = vi.fn(async () => ({ data: { files: [] } }));
+    mockGetDriveClient.mockResolvedValue({ files: { list: filesList } } as any);
+
+    const fakeServer = { addTool: (config: any) => (toolExecute = config.execute) };
+    register(fakeServer as any);
+  });
+
+  it('escapes query text before interpolating it into the Drive query', async () => {
+    await toolExecute(
+      {
+        query: "Bob's \\ budget",
+        maxResults: 10,
+        orderBy: 'modifiedTime',
+      },
+      { log: mockLog }
+    );
+
+    const request = filesList.mock.calls[0][0];
+    expect(request.q).toContain("name contains 'Bob\\'s \\\\ budget'");
+    expect(request.q).toContain("fullText contains 'Bob\\'s \\\\ budget'");
+  });
+});

--- a/src/tools/sheets/listGoogleSheets.ts
+++ b/src/tools/sheets/listGoogleSheets.ts
@@ -2,6 +2,7 @@ import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getDriveClient } from '../../clients.js';
+import { escapeDriveQuery } from '../../driveQueryUtils.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -36,7 +37,8 @@ export function register(server: FastMCP) {
         // Build the query string for Google Drive API
         let queryString = "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false";
         if (args.query) {
-          queryString += ` and (name contains '${args.query}' or fullText contains '${args.query}')`;
+          const escapedQuery = escapeDriveQuery(args.query);
+          queryString += ` and (name contains '${escapedQuery}' or fullText contains '${escapedQuery}')`;
         }
 
         const response = await drive.files.list({


### PR DESCRIPTION
Fixes #100.

## Summary
- Reuse the shared Drive query escaping helper in `listSpreadsheets`.
- Prevent apostrophes and backslashes in sheet search text from breaking the Drive query string.
- Add a regression test that captures the generated Drive query.

## Testing
- `npm test -- src/tools/sheets/listGoogleSheets.test.ts`
- `npm run build`
- `npm run format:check -- src/tools/sheets/listGoogleSheets.ts src/tools/sheets/listGoogleSheets.test.ts`