### PR TITLE
feat: allow registering selected tool groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,18 +317,19 @@ Visit the server root URL (`/`) for setup instructions and a ready-to-copy clien
 
 ### Environment Variables
 
-| Variable               | Description                                                              |
-| ---------------------- | ------------------------------------------------------------------------ |
-| `MCP_TRANSPORT`        | Set to `httpStream` to enable remote mode (default: `stdio`)             |
-| `BASE_URL`             | Public URL of the deployed server (required for OAuth redirects)         |
-| `GOOGLE_CLIENT_ID`     | OAuth client ID (Web application type)                                   |
-| `GOOGLE_CLIENT_SECRET` | OAuth client secret                                                      |
-| `ALLOWED_DOMAINS`      | Comma-separated list of allowed Google Workspace domains (optional)      |
-| `PORT`                 | HTTP port (default: `8080`)                                              |
-| `TOKEN_STORE`          | Set to `firestore` for persistent token storage (default: in-memory)     |
-| `JWT_SIGNING_KEY`      | Fixed signing key so tokens survive restarts (auto-generated if not set) |
-| `REFRESH_TOKEN_TTL`    | Refresh token lifetime in seconds (default: `2592000` / 30 days)         |
-| `GCLOUD_PROJECT`       | GCP project ID for Firestore (required when `TOKEN_STORE=firestore`)     |
+| Variable               | Description                                                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `MCP_TRANSPORT`        | Set to `httpStream` to enable remote mode (default: `stdio`)                                                        |
+| `BASE_URL`             | Public URL of the deployed server (required for OAuth redirects)                                                    |
+| `GOOGLE_CLIENT_ID`     | OAuth client ID (Web application type)                                                                              |
+| `GOOGLE_CLIENT_SECRET` | OAuth client secret                                                                                                 |
+| `MCP_TOOL_GROUPS`      | Optional comma-separated tool groups to register: `docs`, `drive`, `sheets`, `utils`, `gmail`, `calendar`, or `all` |
+| `ALLOWED_DOMAINS`      | Comma-separated list of allowed Google Workspace domains (optional)                                                 |
+| `PORT`                 | HTTP port (default: `8080`)                                                                                         |
+| `TOKEN_STORE`          | Set to `firestore` for persistent token storage (default: in-memory)                                                |
+| `JWT_SIGNING_KEY`      | Fixed signing key so tokens survive restarts (auto-generated if not set)                                            |
+| `REFRESH_TOKEN_TTL`    | Refresh token lifetime in seconds (default: `2592000` / 30 days)                                                    |
+| `GCLOUD_PROJECT`       | GCP project ID for Firestore (required when `TOKEN_STORE=firestore`)                                                |
 
 ### Setup
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
   installCachedToolsListHandler,
 } from './cachedToolsList.js';
 import { initializeGoogleClient } from './clients.js';
-import { registerAllTools } from './tools/index.js';
+import { parseEnabledToolGroups, registerAllTools } from './tools/index.js';
 import { wrapServerForRemote } from './remoteWrapper.js';
 import { registerLandingPage } from './landingPage.js';
 import { registerDownloadRoute } from './downloadProxy.js';
@@ -196,7 +196,15 @@ const server = new FastMCP({
 const registeredTools: Parameters<FastMCP['addTool']>[0][] = [];
 collectToolsWhileRegistering(server, registeredTools);
 if (isRemote) wrapServerForRemote(server);
-registerAllTools(server);
+let enabledToolGroups: ReturnType<typeof parseEnabledToolGroups>;
+try {
+  enabledToolGroups = parseEnabledToolGroups();
+  registerAllTools(server, enabledToolGroups);
+  logger.info(`Registered tool groups: ${enabledToolGroups.join(', ')}.`);
+} catch (error: any) {
+  logger.error(`FATAL: Invalid MCP_TOOL_GROUPS: ${error.message || error}`);
+  process.exit(1);
+}
 
 try {
   if (isRemote) {

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,0 +1,55 @@
+import type { FastMCP } from 'fastmcp';
+import { describe, expect, it } from 'vitest';
+import { parseEnabledToolGroups, registerAllTools, TOOL_GROUPS } from './index.js';
+
+type ToolConfig = Parameters<FastMCP['addTool']>[0];
+
+function captureTools(groups: Parameters<typeof registerAllTools>[1]) {
+  const tools: ToolConfig[] = [];
+  const server = {
+    addTool: (tool: ToolConfig) => {
+      tools.push(tool);
+    },
+  };
+
+  registerAllTools(server as FastMCP, groups);
+  return tools.map((tool) => tool.name);
+}
+
+describe('parseEnabledToolGroups', () => {
+  it('defaults to every tool group', () => {
+    expect(parseEnabledToolGroups(undefined)).toEqual([...TOOL_GROUPS]);
+    expect(parseEnabledToolGroups('  ')).toEqual([...TOOL_GROUPS]);
+  });
+
+  it('normalizes comma-separated tool group names in default order', () => {
+    expect(parseEnabledToolGroups('sheets, docs, sheets')).toEqual(['docs', 'sheets']);
+  });
+
+  it('treats all as the default full registration', () => {
+    expect(parseEnabledToolGroups('all')).toEqual([...TOOL_GROUPS]);
+  });
+
+  it('rejects unknown tool groups', () => {
+    expect(() => parseEnabledToolGroups('docs,unknown')).toThrow('Unknown MCP_TOOL_GROUPS');
+  });
+});
+
+describe('registerAllTools', () => {
+  it('registers only the selected groups', () => {
+    const toolNames = captureTools(['docs']);
+
+    expect(toolNames).toContain('readDocument');
+    expect(toolNames).toContain('appendText');
+    expect(toolNames).not.toContain('listSpreadsheets');
+    expect(toolNames).not.toContain('sendEmail');
+  });
+
+  it('can combine multiple selected groups', () => {
+    const toolNames = captureTools(['docs', 'sheets']);
+
+    expect(toolNames).toContain('readDocument');
+    expect(toolNames).toContain('listSpreadsheets');
+    expect(toolNames).not.toContain('sendEmail');
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,14 +7,62 @@ import { registerUtilsTools } from './utils/index.js';
 import { registerGmailTools } from './gmail/index.js';
 import { registerCalendarTools } from './calendar/index.js';
 
+export const TOOL_GROUPS = ['docs', 'drive', 'sheets', 'utils', 'gmail', 'calendar'] as const;
+
+export type ToolGroup = (typeof TOOL_GROUPS)[number];
+
+const TOOL_GROUP_SET = new Set<string>(TOOL_GROUPS);
+
+export function parseEnabledToolGroups(raw: string | undefined = process.env.MCP_TOOL_GROUPS) {
+  if (!raw?.trim()) return [...TOOL_GROUPS];
+
+  const requested = raw
+    .split(',')
+    .map((group) => group.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (requested.length === 0 || requested.includes('all')) {
+    return [...TOOL_GROUPS];
+  }
+
+  const unknown = requested.filter((group) => !TOOL_GROUP_SET.has(group));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown MCP_TOOL_GROUPS value(s): ${unknown.join(', ')}. Valid groups: ${TOOL_GROUPS.join(', ')}`
+    );
+  }
+
+  const selected = new Set(requested);
+  return TOOL_GROUPS.filter((group) => selected.has(group));
+}
+
 /**
  * Registers all tools with the FastMCP server.
  */
-export function registerAllTools(server: FastMCP) {
-  registerDocsTools(server);
-  registerDriveTools(server);
-  registerSheetsTools(server);
-  registerUtilsTools(server);
-  registerGmailTools(server);
-  registerCalendarTools(server);
+export function registerAllTools(
+  server: FastMCP,
+  enabledGroups: readonly ToolGroup[] = parseEnabledToolGroups()
+) {
+  for (const group of enabledGroups) {
+    switch (group) {
+      case 'docs':
+        registerDocsTools(server);
+        break;
+      case 'drive':
+        registerDriveTools(server);
+        break;
+      case 'sheets':
+        registerSheetsTools(server);
+        break;
+      case 'utils':
+        registerUtilsTools(server);
+        break;
+      case 'gmail':
+        registerGmailTools(server);
+        break;
+      case 'calendar':
+        registerCalendarTools(server);
+        break;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #102.

## Summary
- Add `MCP_TOOL_GROUPS` support for registering only selected tool groups (`docs`, `drive`, `sheets`, `utils`, `gmail`, `calendar`, or `all`).
- Keep the default behavior unchanged by registering every group when the env var is omitted.
- Fail fast on unknown group names and log the registered groups at startup.
- Document the new environment variable.

## Testing
- `npm test -- src/tools/index.test.ts`
- `npm run build`
- `npm run format:check -- src/tools/index.ts src/tools/index.test.ts src/index.ts README.md`