### PR TITLE
fix(auth): omit oauth client secrets from tokens

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ GOOGLE_CLIENT_SECRET="your-client-secret" \
 npm start auth
 ```
 
-Both options save the refresh token to `~/.config/google-docs-mcp/token.json`.
+Both options save the refresh token to `~/.config/google-docs-mcp/token.json`. OAuth client IDs and client secrets stay in your environment or `credentials.json`; they are not stored in the token file.
 
 ### Register Your Local Build
 
@@ -112,7 +112,7 @@ The auth module (`src/auth.ts`) resolves credentials in this order:
 2. `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` env vars -- OAuth (for `npx` consumers)
 3. `credentials.json` in the project root -- OAuth (for local dev)
 
-Tokens are persisted to `~/.config/google-docs-mcp/token.json` (respects `XDG_CONFIG_HOME`).
+Tokens are persisted to `~/.config/google-docs-mcp/token.json` (respects `XDG_CONFIG_HOME`). The token file stores OAuth token credentials only, not OAuth client IDs or client secrets.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ For Google Workspace with domain-wide delegation:
 
 ### Token Storage
 
-OAuth refresh tokens are stored in `~/.config/google-docs-mcp/token.json` (respects `XDG_CONFIG_HOME`). To re-authorize, run the `auth` command again or delete the token file.
+OAuth refresh tokens are stored in `~/.config/google-docs-mcp/token.json` (respects `XDG_CONFIG_HOME`). OAuth client IDs and client secrets are not stored in the token file. To re-authorize, run the `auth` command again or delete the token file.
 
 ### Multiple Google Accounts
 

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { createStoredTokenPayload, sanitizeStoredTokenCredentials } from './auth.js';
+
+describe('OAuth token storage', () => {
+  it('stores only the refresh token after authorization', () => {
+    const payload = createStoredTokenPayload({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      scope: 'https://www.googleapis.com/auth/documents',
+      token_type: 'Bearer',
+      expiry_date: 1234567890,
+    });
+
+    expect(payload).toEqual({ refresh_token: 'refresh-token' });
+  });
+
+  it('ignores OAuth client metadata from legacy token files', () => {
+    const credentials = sanitizeStoredTokenCredentials({
+      type: 'authorized_user',
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+      refresh_token: 'refresh-token',
+      access_token: 'access-token',
+      scope: 'scope-a scope-b',
+      token_type: 'Bearer',
+      expiry_date: 1234567890,
+    });
+
+    expect(credentials).toEqual({
+      refresh_token: 'refresh-token',
+      access_token: 'access-token',
+      scope: 'scope-a scope-b',
+      token_type: 'Bearer',
+      expiry_date: 1234567890,
+    });
+    expect(credentials).not.toHaveProperty('client_id');
+    expect(credentials).not.toHaveProperty('client_secret');
+  });
+
+  it('rejects saved tokens without OAuth token credentials', () => {
+    expect(() =>
+      sanitizeStoredTokenCredentials({
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+      })
+    ).toThrow('Saved token does not contain OAuth token credentials');
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -58,6 +58,44 @@ const SCOPES = [
   'https://www.googleapis.com/auth/calendar.events',
 ];
 
+const TOKEN_CREDENTIAL_FIELDS = ['access_token', 'refresh_token', 'scope', 'token_type'] as const;
+
+export function sanitizeStoredTokenCredentials(
+  rawCredentials: unknown
+): OAuth2Client['credentials'] {
+  if (!rawCredentials || typeof rawCredentials !== 'object' || Array.isArray(rawCredentials)) {
+    throw new Error('Invalid saved token format.');
+  }
+
+  const raw = rawCredentials as Record<string, unknown>;
+  const credentials: Record<string, string | number> = {};
+
+  for (const field of TOKEN_CREDENTIAL_FIELDS) {
+    const value = raw[field];
+    if (typeof value === 'string' && value.length > 0) {
+      credentials[field] = value;
+    }
+  }
+
+  if (typeof raw.expiry_date === 'number') {
+    credentials.expiry_date = raw.expiry_date;
+  }
+
+  if (!credentials.refresh_token && !credentials.access_token) {
+    throw new Error('Saved token does not contain OAuth token credentials.');
+  }
+
+  return credentials as OAuth2Client['credentials'];
+}
+
+export function createStoredTokenPayload(
+  credentials: OAuth2Client['credentials']
+): OAuth2Client['credentials'] {
+  return sanitizeStoredTokenCredentials({
+    refresh_token: credentials.refresh_token,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Client secrets resolution
 // ---------------------------------------------------------------------------
@@ -149,7 +187,7 @@ async function loadSavedCredentialsIfExist(): Promise<OAuth2Client | null> {
   try {
     const tokenPath = getTokenPath();
     const content = await fs.readFile(tokenPath, 'utf8');
-    const credentials = JSON.parse(content);
+    const credentials = sanitizeStoredTokenCredentials(JSON.parse(content));
     const { client_secret, client_id } = await loadClientSecrets();
     const client = new google.auth.OAuth2(client_id, client_secret);
     client.setCredentials(credentials);
@@ -160,19 +198,10 @@ async function loadSavedCredentialsIfExist(): Promise<OAuth2Client | null> {
 }
 
 async function saveCredentials(client: OAuth2Client): Promise<void> {
-  const { client_id } = await loadClientSecrets();
   const configDir = getConfigDir();
   await fs.mkdir(configDir, { recursive: true, mode: 0o700 });
   const tokenPath = getTokenPath();
-  const payload = JSON.stringify(
-    {
-      type: 'authorized_user',
-      client_id,
-      refresh_token: client.credentials.refresh_token,
-    },
-    null,
-    2
-  );
+  const payload = JSON.stringify(createStoredTokenPayload(client.credentials), null, 2);
   await fs.writeFile(tokenPath, payload, { mode: 0o600 });
   logger.info('Token stored to', tokenPath);
 }


### PR DESCRIPTION
## Summary
- save only OAuth token credentials in `token.json`
- ignore `client_id` and `client_secret` when loading legacy token files
- document that OAuth client metadata stays in env vars or `credentials.json`

## Why
The token file should be scoped to user authorization tokens, not OAuth client metadata. This keeps new token files smaller and safer, while still tolerating older token files that may contain `client_id` or `client_secret` fields by stripping those fields before `setCredentials()`.

Fixes #87.

## Tests
- `npm test -- src/auth.test.ts`
- `npm run build`
- `npm run format:check -- src/auth.ts src/auth.test.ts README.md CONTRIBUTING.md`
- `git diff --check`
