### PR TITLE
feat(drive): add setFilePermission tool

### DIFF
--- a/src/tools/drive/index.ts
+++ b/src/tools/drive/index.ts
@@ -14,6 +14,7 @@ import { register as deleteFile } from './deleteFile.js';
 import { register as createDocument } from './createDocument.js';
 import { register as createFromTemplate } from './createFromTemplate.js';
 import { register as downloadFile } from './downloadFile.js';
+import { register as setFilePermission } from './setFilePermission.js';
 
 export function registerDriveTools(server: FastMCP) {
   listGoogleDocs(server);
@@ -31,4 +32,5 @@ export function registerDriveTools(server: FastMCP) {
   createDocument(server);
   createFromTemplate(server);
   downloadFile(server);
+  setFilePermission(server);
 }

--- a/src/tools/drive/setFilePermission.ts
+++ b/src/tools/drive/setFilePermission.ts
@@ -1,0 +1,84 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { drive_v3 } from 'googleapis';
+import { getDriveClient } from '../../clients.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'setFilePermission',
+    description:
+      "Sets a sharing permission on a Drive file or folder. Common case: type='anyone' with role='reader' enables 'anyone with the link can view'. Use type='user' with emailAddress to grant a specific person access. Returns the created permission record.",
+    parameters: z.strictObject({
+      fileId: z
+        .string()
+        .describe('The file or folder ID from a Drive URL or a previous tool result.'),
+      role: z
+        .enum(['reader', 'commenter', 'writer'])
+        .describe(
+          'Access level granted. "reader" = view only, "commenter" = view + comment, "writer" = full edit.'
+        ),
+      type: z
+        .enum(['user', 'group', 'domain', 'anyone'])
+        .describe(
+          'Who this permission applies to. "anyone" means anyone with the link (combine with allowFileDiscovery=false to keep it unlisted).'
+        ),
+      emailAddress: z
+        .string()
+        .optional()
+        .describe("Required when type is 'user' or 'group'."),
+      domain: z.string().optional().describe("Required when type is 'domain'."),
+      sendNotificationEmail: z
+        .boolean()
+        .optional()
+        .describe(
+          'If true, Google sends a notification email when granting access to a user or group. Defaults to false.'
+        ),
+      allowFileDiscovery: z
+        .boolean()
+        .optional()
+        .describe(
+          "Only relevant for type='anyone' or 'domain'. If true, the file is discoverable via search; if false (default), only people with the direct link can find it."
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const drive = await getDriveClient();
+      log.info(`Setting ${args.type}/${args.role} permission on file ${args.fileId}`);
+
+      if ((args.type === 'user' || args.type === 'group') && !args.emailAddress) {
+        throw new UserError(`emailAddress is required when type is "${args.type}".`);
+      }
+      if (args.type === 'domain' && !args.domain) {
+        throw new UserError('domain is required when type is "domain".');
+      }
+
+      const requestBody: drive_v3.Schema$Permission = {
+        role: args.role,
+        type: args.type,
+      };
+      if (args.emailAddress) requestBody.emailAddress = args.emailAddress;
+      if (args.domain) requestBody.domain = args.domain;
+      if (typeof args.allowFileDiscovery === 'boolean')
+        requestBody.allowFileDiscovery = args.allowFileDiscovery;
+
+      try {
+        const response = await drive.permissions.create({
+          fileId: args.fileId,
+          requestBody,
+          sendNotificationEmail: args.sendNotificationEmail ?? false,
+          supportsAllDrives: true,
+          fields: 'id,type,role,emailAddress,domain,allowFileDiscovery',
+        });
+        return JSON.stringify(response.data, null, 2);
+      } catch (error: any) {
+        log.error(`Error setting permission: ${error.message || error}`);
+        if (error.code === 404) throw new UserError('File not found. Check the file ID.');
+        if (error.code === 403)
+          throw new UserError(
+            'Permission denied. You may not have rights to share this file, or the requested permission conflicts with org policy.'
+          );
+        throw new UserError(`Failed to set permission: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adds a `setFilePermission` tool wrapping `drive.permissions.create`, so agents can flip Drive sharing settings (e.g. \"anyone with the link can view\") directly instead of asking a human to click around in the Drive UI.

The motivating use case: an agent generates a file, places it in Drive, and needs an external recipient to access it via a shared link. Without this tool the link returns a permission wall until someone manually adjusts sharing. The other Drive tools (`copyFile`, `createDocument`, etc.) all stop short of letting the file actually be shareable.

## What's in scope

- All four permission types: `user`, `group`, `domain`, `anyone`
- All three roles: `reader`, `commenter`, `writer`
- Standard ancillary flags: `emailAddress`, `domain`, `sendNotificationEmail`, `allowFileDiscovery`
- Validation: throws `UserError` early if `emailAddress` missing for user/group or `domain` missing for domain
- Typed error paths for 403 and 404
- `supportsAllDrives: true` to match the existing Shared Drives pattern documented in `CLAUDE.md`

## OAuth scope

No new scope required — the existing `https://www.googleapis.com/auth/drive` scope already covers `permissions.create`. The CLAUDE.md already lists `permissions.create` as a supported method under \"Shared Drives Support,\" so this is filling in a tool gap rather than expanding capability.

## Files changed

- `src/tools/drive/setFilePermission.ts` (new) — the tool implementation
- `src/tools/drive/index.ts` — import + register

## Testing

Built with `npm run build`. Tool registers correctly and matches the file/style conventions of the other tools in `src/tools/drive/`. I'm running it locally against my own Drive (sharing PDFs out to external recipients) and it works as expected. Happy to add a Vitest file in the style of `downloadFile.test.ts` if you'd like that as part of the PR — let me know.