### PR TITLE
fix(drive): remove ensureWithinCwd restriction from downloadFile

### DIFF
--- a/src/tools/drive/downloadFile.test.ts
+++ b/src/tools/drive/downloadFile.test.ts
@@ -371,6 +371,21 @@ describe('downloadFile integration', () => {
     });
   });
 
+  describe('absolute path outside CWD', () => {
+    it('should accept absolute savePath outside CWD', async () => {
+      createMockDrive();
+
+      const result = await toolExecute(
+        { fileId: 'f1', savePath: '/tmp/test-downloads/report.pdf' },
+        { log: mockLog }
+      );
+
+      const parsed = JSON.parse(result);
+      expect(parsed.savedTo).toBe('/tmp/test-downloads/report.pdf');
+      expect(mockMkdirSync).toHaveBeenCalledWith('/tmp/test-downloads', { recursive: true });
+    });
+  });
+
   describe('unsupported workspace type', () => {
     it('should throw UserError for types without export defaults', async () => {
       createMockDrive({

--- a/src/tools/drive/downloadFile.ts
+++ b/src/tools/drive/downloadFile.ts
@@ -46,14 +46,6 @@ function isWorkspaceMimeType(mime: string): boolean {
   return mime.startsWith('application/vnd.google-apps.');
 }
 
-function ensureWithinCwd(filePath: string): string {
-  const cwd = path.resolve(process.cwd());
-  const resolved = path.resolve(filePath);
-  if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
-    throw new UserError('File path must be within the working directory.');
-  }
-  return resolved;
-}
 
 const DownloadFileParameters = z.strictObject({
   fileId: z.string().describe('The file ID from a Google Drive URL or previous tool result.'),
@@ -239,7 +231,7 @@ export function register(server: FastMCP) {
 
         // ---------- Stdio mode: write to local disk ----------
         resolvedSavePath = args.savePath;
-        if (resolvedSavePath) resolvedSavePath = ensureWithinCwd(resolvedSavePath);
+        if (resolvedSavePath) resolvedSavePath = path.resolve(resolvedSavePath);
 
         if (!resolvedSavePath) {
           if (isWorkspace && exportMime) {
@@ -250,7 +242,7 @@ export function register(server: FastMCP) {
             resolvedSavePath = path.join(process.cwd(), fileName);
           }
         }
-        resolvedSavePath = ensureWithinCwd(resolvedSavePath);
+        resolvedSavePath = path.resolve(resolvedSavePath);
 
         fs.mkdirSync(path.dirname(resolvedSavePath), { recursive: true });
 


### PR DESCRIPTION
### What this PR does

Removes the `ensureWithinCwd` function from the `downloadFile` tool and replaces both call sites with plain `path.resolve()`. This allows stdio-mode MCP clients to save downloaded files to arbitrary absolute paths on the local filesystem.

### Why these changes are necessary

The `ensureWithinCwd` function rejects any `savePath` that is not within the MCP server process's current working directory (CWD). In practice, this makes `downloadFile` broken for stdio-mode callers such as Antigravity, Cursor, and Claude Desktop, because:

1. The MCP server's CWD is set by the host application — typically the user's home directory or an app data directory — **not** the user's workspace.
2. Clients naturally pass absolute workspace paths (e.g. `/Users/alice/projects/my-app/data/report.pdf`), which are always outside the server's CWD.
3. The restriction provides limited security: the MCP server is already a trusted local process running with the user's full filesystem and Google API permissions.

Remote/httpStream mode is unaffected — it returns download URLs or inline content and never calls `ensureWithinCwd`.

The default behavior when `savePath` is omitted (save to CWD + filename) is preserved via `path.resolve()`.

### Testing

- All 240 existing tests pass (0 failures).
- Added a new test confirming absolute paths outside CWD are now accepted.
- Verified TypeScript compilation succeeds with no errors.