### PR TITLE
fix(drive): fail loudly when createDocument can't insert initialContent

### DIFF
--- a/src/tools/drive/createDocument.ts
+++ b/src/tools/drive/createDocument.ts
@@ -54,7 +54,13 @@ export function register(server: FastMCP) {
 
         const document = response.data;
 
-        // Add initial content if provided
+        // Add initial content if provided.
+        // NOTE: the Drive file already exists at this point, so the doc is created
+        // *empty* and content is a second API call. If that second call fails we must
+        // NOT report success — doing so silently leaves an empty document. Surface the
+        // failure loudly, including the doc id/url so the caller can append to the
+        // existing doc instead of creating a duplicate.
+        let contentInserted = false;
         if (args.initialContent) {
           try {
             const docs = await getDocsClient();
@@ -79,8 +85,16 @@ export function register(server: FastMCP) {
               });
               log.info(formatInsertResult(result));
             }
+            contentInserted = true;
           } catch (contentError: any) {
-            log.warn(`Document created but failed to add initial content: ${contentError.message}`);
+            const detail = contentError?.message || String(contentError);
+            log.error(`Document created but failed to add initial content: ${detail}`);
+            throw new UserError(
+              `Document "${document.name}" was created (id: ${document.id}, url: ${document.webViewLink}) ` +
+                `but inserting the initial content FAILED, so it is currently EMPTY. ` +
+                `Append the content to this existing document (do not create a new one). ` +
+                `Underlying error: ${detail}`
+            );
           }
         }
 
@@ -89,11 +103,14 @@ export function register(server: FastMCP) {
             id: document.id,
             name: document.name,
             url: document.webViewLink,
+            contentInserted,
           },
           null,
           2
         );
       } catch (error: any) {
+        // Pass through UserErrors we raised above (e.g. created-but-empty) unchanged.
+        if (error instanceof UserError) throw error;
         log.error(`Error creating document: ${error.message || error}`);
         if (error.code === 404)
           throw new UserError('Parent folder not found. Check the folder ID.');


### PR DESCRIPTION
## Problem

`createDocument` creates the Drive file **empty**, then inserts `initialContent` in a second `documents.batchUpdate` call. That second call is wrapped in a `try/catch` that logs a warning and then returns the success payload regardless:

```ts
} catch (contentError: any) {
  log.warn(`Document created but failed to add initial content: ${contentError.message}`);
}
// ...returns { id, name, url } as success
```

So when the content insertion fails, the tool still reports success with a doc id/url, and the caller (an LLM, typically) treats the document as written. The user opens it and finds it **empty** — with no error to explain why. In practice this shows up as a recurring "I have to go seed the doc by hand" problem, because the failure is invisible to whatever is driving the tool.

## Fix

- On content-insertion failure, throw a `UserError` instead of swallowing it. The message names the **created document's id and url** so the caller can append to the existing doc rather than creating a duplicate.
- The outer `catch` now re-throws `UserError`s unchanged, so this isn't relabeled `Failed to create document` (the document *was* created — only the content step failed).
- Success responses gain a `contentInserted` boolean so callers can confirm content actually landed.

No behavior change on the happy path; this only affects the previously-silent failure case.

## Notes

Found while debugging recurring empty-doc creations in a Claude-driven setup. Happy to adjust the approach (e.g. trash the empty doc on failure instead of surfacing it) if you'd prefer different semantics.