### PR TITLE
#137(docs): Docs tool errors with subtabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a-bonus/google-docs-mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a-bonus/google-docs-mcp",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/firestore": "^8.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a-bonus/google-docs-mcp",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a-bonus/google-docs-mcp",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/firestore": "^8.3.0",
@@ -642,9 +642,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -808,25 +808,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -836,9 +835,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -854,9 +853,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1528,14 +1527,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -2161,12 +2186,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2191,9 +2216,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2344,9 +2369,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2765,9 +2790,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2927,9 +2952,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3337,9 +3362,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3545,9 +3570,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3612,9 +3637,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3632,7 +3657,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3684,24 +3709,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3721,10 +3746,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -3755,9 +3783,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4544,9 +4572,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a-bonus/google-docs-mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "bin": {
     "google-docs-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "start": "node ./dist/index.js",
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "vitest run",
     "test:live:docs": "vitest run src/tools/docs/cloneTable.live.test.ts",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "start": "node ./dist/index.js",
     "build": "tsc",
-    "prepare": "npm run build",
     "test": "vitest run",
     "test:live:docs": "vitest run src/tools/docs/cloneTable.live.test.ts",
     "format": "prettier --write .",

--- a/src/googleDocsApiHelpers.ts
+++ b/src/googleDocsApiHelpers.ts
@@ -4,6 +4,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { UserError } from 'fastmcp';
 import { TextStyleArgs, ParagraphStyleArgs, hexToRgbColor, NotImplementedError } from './types.js';
 import { logger } from './logger.js';
+import { buildTabsFieldMask } from './tools/docs/tabFieldMasks.js';
 
 type Docs = docs_v1.Docs; // Alias for convenience
 
@@ -238,7 +239,9 @@ export async function findTextRange(
       ...(needsTabsContent && { includeTabsContent: true }),
       // Request more fields to handle various container types (not just paragraphs)
       fields: needsTabsContent
-        ? 'tabs(tabProperties(tabId),documentTab(body(content(paragraph(elements(startIndex,endIndex,textRun(content))),table,sectionBreak,tableOfContents,startIndex,endIndex))))'
+        ? buildTabsFieldMask(
+            'documentTab(body(content(paragraph(elements(startIndex,endIndex,textRun(content))),table,sectionBreak,tableOfContents,startIndex,endIndex)))'
+          )
         : 'body(content(paragraph(elements(startIndex,endIndex,textRun(content))),table,sectionBreak,tableOfContents,startIndex,endIndex))',
     });
 
@@ -419,7 +422,9 @@ export async function getParagraphRange(
       ...(needsTabsContent && { includeTabsContent: true }),
       // Request more comprehensive structure information
       fields: needsTabsContent
-        ? 'tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex,paragraph,table,sectionBreak,tableOfContents))))'
+        ? buildTabsFieldMask(
+            'documentTab(body(content(startIndex,endIndex,paragraph,table,sectionBreak,tableOfContents)))'
+          )
         : 'body(content(startIndex,endIndex,paragraph,table,sectionBreak,tableOfContents))',
     });
 
@@ -1396,4 +1401,78 @@ export function findTabById(
   };
 
   return searchTabs(doc.tabs);
+}
+
+/**
+ * Fetches a document with tab content and validates that the given tabId exists and has
+ * a documentTab body. Returns the resolved `docs_v1.Schema$Tab`.
+ *
+ * This replaces the repeated pattern:
+ *   docs.documents.get({ includeTabsContent: true, fields: buildTabsFieldMask(...) })
+ *   + findTabById() + two UserError throws
+ *
+ * @param docs     - Authenticated Docs client
+ * @param documentId - Target document ID
+ * @param tabId    - Tab ID to locate
+ * @param documentTabFields - The documentTab subfields needed (passed to buildTabsFieldMask)
+ */
+export async function getDocumentTab(
+  docs: Docs,
+  documentId: string,
+  tabId: string,
+  documentTabFields: string = 'documentTab(body(content(endIndex)))'
+): Promise<docs_v1.Schema$Tab> {
+  const res = await docs.documents.get({
+    documentId,
+    includeTabsContent: true,
+    suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
+    fields: buildTabsFieldMask(documentTabFields),
+  });
+  const tab = findTabById(res.data, tabId);
+  if (!tab) {
+    throw new UserError(`Tab with ID "${tabId}" not found in document.`);
+  }
+  if (!tab.documentTab) {
+    throw new UserError(`Tab "${tabId}" does not have content (may not be a document tab).`);
+  }
+  return tab;
+}
+
+/**
+ * Returns the 1-based insertion index for appending to a document or tab body —
+ * i.e. `endIndex - 1` of the last structural element, which positions content
+ * immediately before the document's trailing newline.
+ *
+ * @param docs        - Authenticated Docs client
+ * @param documentId  - Target document ID
+ * @param tabId       - Optional tab ID; if omitted uses the root body
+ */
+export async function getAppendIndex(
+  docs: Docs,
+  documentId: string,
+  tabId?: string
+): Promise<number> {
+  const needsTabsContent = !!tabId;
+  const res = await docs.documents.get({
+    documentId,
+    ...(needsTabsContent && { includeTabsContent: true }),
+    suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
+    fields: needsTabsContent
+      ? buildTabsFieldMask('documentTab(body(content(endIndex)))')
+      : 'body(content(endIndex))',
+  });
+
+  let content: docs_v1.Schema$StructuralElement[] | undefined;
+  if (tabId) {
+    const tab = findTabById(res.data, tabId);
+    if (!tab) throw new UserError(`Tab with ID "${tabId}" not found in document.`);
+    if (!tab.documentTab) throw new UserError(`Tab "${tabId}" does not have content.`);
+    content = tab.documentTab.body?.content;
+  } else {
+    content = res.data.body?.content;
+  }
+
+  if (!content || content.length === 0) return 1;
+  const lastEndIndex = content[content.length - 1]?.endIndex;
+  return lastEndIndex != null ? lastEndIndex - 1 : 1;
 }

--- a/src/tools/docs/addTab.ts
+++ b/src/tools/docs/addTab.ts
@@ -44,15 +44,7 @@ export function register(server: FastMCP) {
       try {
         // If parentTabId is provided, verify it exists
         if (args.parentTabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body))',
-          });
-          const parentTab = GDocsHelpers.findTabById(docInfo.data, args.parentTabId);
-          if (!parentTab) {
-            throw new UserError(`Parent tab with ID "${args.parentTabId}" not found in document.`);
-          }
+          await GDocsHelpers.getDocumentTab(docs, args.documentId, args.parentTabId);
         }
 
         const tabProperties: Record<string, unknown> = {};

--- a/src/tools/docs/appendTableRows.ts
+++ b/src/tools/docs/appendTableRows.ts
@@ -6,6 +6,7 @@ import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { DocumentIdParameter } from '../../types.js';
 import { getTableById } from './structureHelpers.js';
 import { replaceTableRowData as replaceTableRowDataInternal } from './tableRowDataHelpers.js';
+import { TABLE_CONTENT_INDEXED_BODY_FIELDS, buildDocumentGetFields } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -36,11 +37,14 @@ export function register(server: FastMCP) {
       );
 
       try {
+        const tableRowFieldMask = buildDocumentGetFields(
+          TABLE_CONTENT_INDEXED_BODY_FIELDS,
+          args.tabId
+        );
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: tableRowFieldMask,
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);
@@ -76,9 +80,8 @@ export function register(server: FastMCP) {
 
         const refreshed = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: tableRowFieldMask,
         });
 
         const updatedTable = getTableById(refreshed.data, args.tableId, args.tabId);
@@ -95,9 +98,8 @@ export function register(server: FastMCP) {
                   (
                     await docs.documents.get({
                       documentId: args.documentId,
-                      includeTabsContent: true,
-                      fields:
-                        'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+                      ...(args.tabId && { includeTabsContent: true }),
+                      fields: tableRowFieldMask,
                     })
                   ).data,
                   args.tableId,

--- a/src/tools/docs/cloneTable.ts
+++ b/src/tools/docs/cloneTable.ts
@@ -7,9 +7,13 @@ import { DocumentIdParameter } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { buildInsertTableWithDataRequests } from './insertTableWithData.js';
 import { extractDocumentTables, extractTableSnapshot } from './structureHelpers.js';
+import { buildDocumentGetFields } from './tabFieldMasks.js';
 
-const CLONE_TABLE_SOURCE_FIELDS =
-  'tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))))))';
+const CLONE_TABLE_SOURCE_BODY_FIELDS =
+  'body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))))';
+
+const CLONE_TABLE_TARGET_BODY_FIELDS =
+  'body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content)))))))))';
 
 const CloneTableParameters = DocumentIdParameter.extend({
   sourceDocumentId: z.string().min(1).describe('Document ID containing the source table template.'),
@@ -73,8 +77,8 @@ export function register(server: FastMCP) {
       try {
         const sourceRes = await docs.documents.get({
           documentId: args.sourceDocumentId,
-          includeTabsContent: true,
-          fields: CLONE_TABLE_SOURCE_FIELDS,
+          ...(args.sourceTabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(CLONE_TABLE_SOURCE_BODY_FIELDS, args.sourceTabId),
         });
 
         const snapshot = extractTableSnapshot(sourceRes.data, args.sourceTableId, args.sourceTabId);
@@ -90,17 +94,7 @@ export function register(server: FastMCP) {
         }
 
         if (args.targetTabId) {
-          const targetInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body))',
-          });
-          const targetTab = GDocsHelpers.findTabById(targetInfo.data, args.targetTabId);
-          if (!targetTab)
-            throw new UserError(`Target tab "${args.targetTabId}" not found in document.`);
-          if (!targetTab.documentTab) {
-            throw new UserError(`Target tab "${args.targetTabId}" does not have document content.`);
-          }
+          await GDocsHelpers.getDocumentTab(docs, args.documentId, args.targetTabId);
         }
 
         const insertRequests = buildInsertTableWithDataRequests(
@@ -118,9 +112,8 @@ export function register(server: FastMCP) {
 
         const targetRes = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+          ...(args.targetTabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(CLONE_TABLE_TARGET_BODY_FIELDS, args.targetTabId),
         });
 
         const targetTable = extractDocumentTables(targetRes.data, args.targetTabId)

--- a/src/tools/docs/deleteRange.ts
+++ b/src/tools/docs/deleteRange.ts
@@ -47,20 +47,7 @@ export function register(server: FastMCP) {
       try {
         // If tabId is specified, verify the tab exists
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const range: any = {

--- a/src/tools/docs/deleteTableRows.ts
+++ b/src/tools/docs/deleteTableRows.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { getTableById } from './structureHelpers.js';
+import { TABLE_CONTENT_BASIC_BODY_FIELDS, buildDocumentGetFields } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -34,9 +35,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_CONTENT_BASIC_BODY_FIELDS, args.tabId),
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);

--- a/src/tools/docs/findSectionsByHeading.ts
+++ b/src/tools/docs/findSectionsByHeading.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import { findHeadings } from './structureHelpers.js';
+import { HEADING_BODY_FIELDS, buildDocumentGetFields } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -32,9 +33,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,paragraph(paragraphStyle(namedStyleType),elements(textRun(content))),table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,paragraph(paragraphStyle(namedStyleType),elements(textRun(content))),table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(HEADING_BODY_FIELDS, args.tabId),
         });
 
         const sections = findHeadings(res.data, args.headings, args.tabId);

--- a/src/tools/docs/formatting/updateTableBorders.ts
+++ b/src/tools/docs/formatting/updateTableBorders.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../../clients.js';
 import { DocumentIdParameter, validateHexColor, hexToRgbColor } from '../../../types.js';
 import { getTableById } from '../structureHelpers.js';
 import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
+import { TABLE_INDEX_BODY_FIELDS, buildDocumentGetFields } from '../tabFieldMasks.js';
 
 const BorderSideSchema = z.strictObject({
   color: z
@@ -49,9 +50,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_INDEX_BODY_FIELDS, args.tabId),
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);

--- a/src/tools/docs/formatting/updateTableCellStyle.ts
+++ b/src/tools/docs/formatting/updateTableCellStyle.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../../clients.js';
 import { getTableById } from '../structureHelpers.js';
 import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
 import { DocumentIdParameter, validateHexColor, hexToRgbColor } from '../../../types.js';
+import { TABLE_INDEX_BODY_FIELDS, buildDocumentGetFields } from '../tabFieldMasks.js';
 
 const HexColor = z
   .string()
@@ -48,9 +49,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_INDEX_BODY_FIELDS, args.tabId),
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);

--- a/src/tools/docs/formatting/updateTableColumnWidth.ts
+++ b/src/tools/docs/formatting/updateTableColumnWidth.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../../clients.js';
 import { DocumentIdParameter } from '../../../types.js';
 import { getTableById } from '../structureHelpers.js';
 import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
+import { TABLE_INDEX_BODY_FIELDS, buildDocumentGetFields } from '../tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -28,9 +29,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_INDEX_BODY_FIELDS, args.tabId),
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);

--- a/src/tools/docs/formatting/updateTableRowStyle.ts
+++ b/src/tools/docs/formatting/updateTableRowStyle.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../../clients.js';
 import { DocumentIdParameter } from '../../../types.js';
 import { getTableById } from '../structureHelpers.js';
 import * as GDocsHelpers from '../../../googleDocsApiHelpers.js';
+import { TABLE_INDEX_BODY_FIELDS, buildDocumentGetFields } from '../tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -47,9 +48,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_INDEX_BODY_FIELDS, args.tabId),
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);

--- a/src/tools/docs/getTableStructure.ts
+++ b/src/tools/docs/getTableStructure.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import { getTableById } from './structureHelpers.js';
+import { TABLE_CONTENT_INDEXED_BODY_FIELDS, buildDocumentGetFields } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -31,9 +32,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(textRun(content)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_CONTENT_INDEXED_BODY_FIELDS, args.tabId),
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);

--- a/src/tools/docs/insertDateChip.ts
+++ b/src/tools/docs/insertDateChip.ts
@@ -65,18 +65,7 @@ export function register(server: FastMCP) {
 
       try {
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const location: Record<string, unknown> = { index: args.index };

--- a/src/tools/docs/insertImage.ts
+++ b/src/tools/docs/insertImage.ts
@@ -51,20 +51,7 @@ export function register(server: FastMCP) {
 
       try {
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         // --- Apps Script path: local files when APPS_SCRIPT_DEPLOYMENT_ID is set ---

--- a/src/tools/docs/insertPageBreak.ts
+++ b/src/tools/docs/insertPageBreak.ts
@@ -33,20 +33,7 @@ export function register(server: FastMCP) {
       try {
         // If tabId is specified, verify the tab exists
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const location: any = { index: args.index };

--- a/src/tools/docs/insertPerson.ts
+++ b/src/tools/docs/insertPerson.ts
@@ -34,18 +34,7 @@ export function register(server: FastMCP) {
 
       try {
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const location: Record<string, unknown> = { index: args.index };

--- a/src/tools/docs/insertRichLink.ts
+++ b/src/tools/docs/insertRichLink.ts
@@ -53,18 +53,7 @@ export function register(server: FastMCP) {
 
       try {
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const location: Record<string, unknown> = { index: args.index };

--- a/src/tools/docs/insertSectionBreak.ts
+++ b/src/tools/docs/insertSectionBreak.ts
@@ -56,20 +56,7 @@ export function register(server: FastMCP) {
       );
       try {
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const request = buildInsertSectionBreakRequest({

--- a/src/tools/docs/insertTable.ts
+++ b/src/tools/docs/insertTable.ts
@@ -35,20 +35,7 @@ export function register(server: FastMCP) {
       try {
         // If tabId is specified, verify the tab exists
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body(content(endIndex))))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         await GDocsHelpers.createTable(

--- a/src/tools/docs/insertTableWithData.ts
+++ b/src/tools/docs/insertTableWithData.ts
@@ -142,21 +142,7 @@ export function register(server: FastMCP) {
       try {
         // Validate tab if specified (same pattern as insertTable.ts)
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
-            fields: 'tabs(tabProperties(tabId),documentTab(body(content(startIndex,endIndex))))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const requests = buildInsertTableWithDataRequests(

--- a/src/tools/docs/insertText.ts
+++ b/src/tools/docs/insertText.ts
@@ -34,22 +34,7 @@ export function register(server: FastMCP) {
       );
       try {
         if (args.tabId) {
-          // For tab-specific inserts, we need to verify the tab exists first
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
-            fields: 'tabs(tabProperties(tabId))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
 
           // Insert with tabId
           const location: any = { index: args.index, tabId: args.tabId };

--- a/src/tools/docs/listDocumentTables.ts
+++ b/src/tools/docs/listDocumentTables.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import { extractDocumentTables } from './structureHelpers.js';
+import { TABLE_CONTENT_BASIC_BODY_FIELDS, buildDocumentGetFields } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -27,9 +28,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_CONTENT_BASIC_BODY_FIELDS, args.tabId),
         });
 
         const tables = extractDocumentTables(res.data, args.tabId).map((table) => ({

--- a/src/tools/docs/listSmartChips.ts
+++ b/src/tools/docs/listSmartChips.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import { extractSmartChips } from './smartChipHelpers.js';
+import { SMART_CHIP_BODY_FIELDS, buildDocumentGetFields } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -27,9 +28,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties))),table(tableRows(tableCells(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties))),table(tableRows(tableCells(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(SMART_CHIP_BODY_FIELDS, args.tabId),
         });
 
         const chips = extractSmartChips(res.data, args.tabId);

--- a/src/tools/docs/modifyText.ts
+++ b/src/tools/docs/modifyText.ts
@@ -123,21 +123,7 @@ export function register(server: FastMCP) {
       try {
         // Verify tab exists if specified
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
-            fields: 'tabs(tabProperties(tabId))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         // Resolve target to numeric indices

--- a/src/tools/docs/readGoogleDoc.ts
+++ b/src/tools/docs/readGoogleDoc.ts
@@ -5,6 +5,7 @@ import { getDocsClient, getDriveClient } from '../../clients.js';
 import { DocumentIdParameter, NotImplementedError } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { docsJsonToMarkdown } from '../../markdown-transformer/index.js';
+import { buildTabsFieldMask } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -50,8 +51,9 @@ export function register(server: FastMCP) {
         const res = await docs.documents.get({
           documentId: args.documentId,
           includeTabsContent: needsTabsContent,
+          suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
           fields: needsTabsContent
-            ? 'title,documentId,tabs(tabProperties,childTabs,documentTab(body,documentStyle,namedStyles,lists,inlineObjects,positionedObjects))'
+            ? `title,documentId,${buildTabsFieldMask('documentTab(body,documentStyle,namedStyles,lists)')}`
             : fields,
         });
         log.info(`Fetched doc: ${args.documentId}${args.tabId ? ` (tab: ${args.tabId})` : ''}`);
@@ -105,33 +107,27 @@ export function register(server: FastMCP) {
         let textContent = '';
         let elementCount = 0;
 
+        const extractFromElements = (elements: any[]) => {
+          for (const element of elements || []) {
+            elementCount++;
+            if (element.paragraph?.elements) {
+              for (const pe of element.paragraph.elements) {
+                if (pe.textRun?.content) textContent += pe.textRun.content;
+              }
+            }
+            if (element.table?.tableRows) {
+              for (const row of element.table.tableRows) {
+                for (const cell of row.tableCells || []) {
+                  extractFromElements(cell.content || []);
+                }
+              }
+            }
+          }
+        };
+
         // Process all content elements from contentSource
         contentSource.body?.content?.forEach((element: any) => {
-          elementCount++;
-
-          // Handle paragraphs
-          if (element.paragraph?.elements) {
-            element.paragraph.elements.forEach((pe: any) => {
-              if (pe.textRun?.content) {
-                textContent += pe.textRun.content;
-              }
-            });
-          }
-
-          // Handle tables
-          if (element.table?.tableRows) {
-            element.table.tableRows.forEach((row: any) => {
-              row.tableCells?.forEach((cell: any) => {
-                cell.content?.forEach((cellElement: any) => {
-                  cellElement.paragraph?.elements?.forEach((pe: any) => {
-                    if (pe.textRun?.content) {
-                      textContent += pe.textRun.content;
-                    }
-                  });
-                });
-              });
-            });
-          }
+          extractFromElements([element]);
         });
 
         if (!textContent.trim()) return 'Document found, but appears empty.';

--- a/src/tools/docs/renameTab.ts
+++ b/src/tools/docs/renameTab.ts
@@ -23,40 +23,23 @@ export function register(server: FastMCP) {
 
       try {
         // Verify the tab exists
-        const docInfo = await docs.documents.get({
-          documentId: args.documentId,
-          includeTabsContent: true,
-          fields: 'tabs(tabProperties,documentTab(body))',
-        });
-        const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-        if (!targetTab) {
-          throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-        }
+        const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
 
-        const oldTitle = targetTab.tabProperties?.title || '(untitled)';
-
-        await docs.documents.batchUpdate({
-          documentId: args.documentId,
-          requestBody: {
-            requests: [
-              {
-                updateDocumentTabProperties: {
-                  tabProperties: {
-                    tabId: args.tabId,
-                    title: args.newTitle,
-                  },
-                  fields: 'title',
-                },
+        await GDocsHelpers.executeBatchUpdate(docs, args.documentId, [
+          {
+            updateDocumentTabProperties: {
+              tabProperties: {
+                tabId: args.tabId,
+                title: args.newTitle,
               },
-            ],
-          },
-        });
+              fields: 'title',
+            },
+          } as any,
+        ]);
 
-        return `Successfully renamed tab from "${oldTitle}" to "${args.newTitle}".`;
+        return `Successfully renamed tab "${args.tabId}" to "${args.newTitle}".`;
       } catch (error: any) {
-        log.error(
-          `Error renaming tab ${args.tabId} in doc ${args.documentId}: ${error.message || error}`
-        );
+        log.error(`Error renaming tab in doc ${args.documentId}: ${error.message || error}`);
         if (error instanceof UserError) throw error;
         if (error.code === 404) throw new UserError(`Document not found (ID: ${args.documentId}).`);
         if (error.code === 403)

--- a/src/tools/docs/replaceTableRowData.ts
+++ b/src/tools/docs/replaceTableRowData.ts
@@ -5,6 +5,7 @@ import { getDocsClient } from '../../clients.js';
 import { DocumentIdParameter } from '../../types.js';
 import { getTableById } from './structureHelpers.js';
 import { replaceTableRowData as replaceTableRowDataInternal } from './tableRowDataHelpers.js';
+import { TABLE_CONTENT_INDEXED_BODY_FIELDS, buildDocumentGetFields } from './tabFieldMasks.js';
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -37,9 +38,8 @@ export function register(server: FastMCP) {
       try {
         const res = await docs.documents.get({
           documentId: args.documentId,
-          includeTabsContent: true,
-          fields:
-            'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+          ...(args.tabId && { includeTabsContent: true }),
+          fields: buildDocumentGetFields(TABLE_CONTENT_INDEXED_BODY_FIELDS, args.tabId),
         });
 
         const table = getTableById(res.data, args.tableId, args.tabId);

--- a/src/tools/docs/structureHelpers.test.ts
+++ b/src/tools/docs/structureHelpers.test.ts
@@ -1,6 +1,83 @@
 import { describe, expect, it } from 'vitest';
 import { extractDocumentTables, findHeadings, getTableById } from './structureHelpers.js';
 
+// Shared tabbed-document fixture — represents the shape returned by
+// documents.get when includeTabsContent: true and a tabs field mask is used.
+const mockTabbedDocument = {
+  // No top-level body — only tabs are populated when includeTabsContent: true
+  tabs: [
+    {
+      tabProperties: { tabId: 'tab-a', title: 'Main' },
+      documentTab: {
+        body: {
+          content: [
+            {
+              startIndex: 1,
+              endIndex: 20,
+              paragraph: {
+                paragraphStyle: { namedStyleType: 'HEADING_1' },
+                elements: [{ textRun: { content: 'Sprint Tasks\n' } }],
+              },
+            },
+            {
+              startIndex: 20,
+              endIndex: 80,
+              table: {
+                tableRows: [
+                  {
+                    tableCells: [
+                      {
+                        startIndex: 25,
+                        endIndex: 35,
+                        content: [{ paragraph: { elements: [{ textRun: { content: 'No.\n' } }] } }],
+                      },
+                      {
+                        startIndex: 35,
+                        endIndex: 50,
+                        content: [
+                          { paragraph: { elements: [{ textRun: { content: 'Task\n' } }] } },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      tabProperties: { tabId: 'tab-b', title: 'Notes' },
+      documentTab: {
+        body: {
+          content: [
+            {
+              startIndex: 1,
+              endIndex: 15,
+              table: {
+                tableRows: [
+                  {
+                    tableCells: [
+                      {
+                        startIndex: 5,
+                        endIndex: 14,
+                        content: [
+                          { paragraph: { elements: [{ textRun: { content: 'Note\n' } }] } },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+} as any;
+
 const mockDocument = {
   body: {
     content: [
@@ -165,5 +242,65 @@ describe('structureHelpers', () => {
         tableIdFollowing: undefined,
       },
     ]);
+  });
+});
+
+// ── Tabbed document tests ────────────────────────────────────────────────────
+// These tests guard the path that was broken before the field mask fix:
+// when tabId is provided, documents.get returns tabs[].documentTab.body rather
+// than doc.body. All structure helpers must read from the correct source.
+describe('structureHelpers — tabbed document path', () => {
+  it('extractDocumentTables scopes to the specified tab', () => {
+    const tabATables = extractDocumentTables(mockTabbedDocument, 'tab-a');
+    expect(tabATables).toHaveLength(1);
+    expect(tabATables[0].tableId).toBe('table:tab-a:0');
+    expect(tabATables[0].rowCount).toBe(1);
+    expect(tabATables[0].columnCount).toBe(2);
+    expect(tabATables[0].startIndex).toBe(20);
+
+    const tabBTables = extractDocumentTables(mockTabbedDocument, 'tab-b');
+    expect(tabBTables).toHaveLength(1);
+    expect(tabBTables[0].tableId).toBe('table:tab-b:0');
+    expect(tabBTables[0].columnCount).toBe(1);
+  });
+
+  it('extractDocumentTables does NOT bleed across tabs', () => {
+    // Tab A has a 2-column table; tab B has a 1-column table.
+    // Reading tab B should never return the tab A table.
+    const tabBTables = extractDocumentTables(mockTabbedDocument, 'tab-b');
+    expect(tabBTables.every((t) => t.tableId.startsWith('table:tab-b:'))).toBe(true);
+    expect(tabBTables.find((t) => t.columnCount === 2)).toBeUndefined();
+  });
+
+  it('getTableById returns null for an ID from a different tab', () => {
+    // table:tab-a:0 should not be found when querying tab-b
+    const result = getTableById(mockTabbedDocument, 'table:tab-a:0', 'tab-b');
+    expect(result).toBeNull();
+  });
+
+  it('getTableById finds the table when the correct tabId is provided', () => {
+    const result = getTableById(mockTabbedDocument, 'table:tab-a:0', 'tab-a');
+    expect(result).not.toBeNull();
+    expect(result!.tableId).toBe('table:tab-a:0');
+  });
+
+  it('findHeadings reads from the correct tab', () => {
+    const sections = findHeadings(mockTabbedDocument, ['Sprint Tasks'], 'tab-a');
+    expect(sections).toHaveLength(1);
+    expect(sections[0].headingText).toBe('Sprint Tasks');
+    expect(sections[0].headingLevel).toBe('HEADING_1');
+  });
+
+  it('findHeadings returns empty for a heading that only exists in another tab', () => {
+    // 'Sprint Tasks' is in tab-a only — should not be found when scoped to tab-b
+    const sections = findHeadings(mockTabbedDocument, ['Sprint Tasks'], 'tab-b');
+    expect(sections).toHaveLength(0);
+  });
+
+  it('extractDocumentTables returns empty array for an unknown tabId', () => {
+    // Before the fix, an unknown tabId would silently fall back to doc.body
+    // or throw. Now getContentSource returns [] for a missing tab.
+    const tables = extractDocumentTables(mockTabbedDocument, 'tab-does-not-exist');
+    expect(tables).toHaveLength(0);
   });
 });

--- a/src/tools/docs/tabFieldMasks.test.ts
+++ b/src/tools/docs/tabFieldMasks.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { TAB_FIELD_MASKS } from './tabFieldMasks.js';
+import {
+  TAB_FIELD_MASKS,
+  TABLE_INDEX_BODY_FIELDS,
+  TABLE_CONTENT_BASIC_BODY_FIELDS,
+  TABLE_CONTENT_INDEXED_BODY_FIELDS,
+  HEADING_BODY_FIELDS,
+  SMART_CHIP_BODY_FIELDS,
+  buildDocumentGetFields,
+} from './tabFieldMasks.js';
 
 describe('Google Docs tab field masks', () => {
   it('uses explicit tab properties instead of broad tab expansions', () => {
@@ -8,6 +16,53 @@ describe('Google Docs tab field masks', () => {
       expect(mask).not.toContain('tabProperties,');
       expect(mask).not.toContain('childTabs(tabProperties,');
       expect(mask).toContain('tabProperties(tabId');
+    }
+  });
+});
+
+describe('buildDocumentGetFields', () => {
+  it('returns the body fields unchanged when no tabId is provided', () => {
+    const result = buildDocumentGetFields(TABLE_INDEX_BODY_FIELDS);
+    expect(result).toBe(TABLE_INDEX_BODY_FIELDS);
+    expect(result).toMatch(/^body\(/);
+    // Must not contain any tabs field mask wrapper — this would cause the
+    // "Field mask cannot retrieve document.tabs and legacy text-level fields"
+    // API error when passed alongside includeTabsContent: false
+    expect(result).not.toContain('tabs(');
+    expect(result).not.toContain('tabProperties');
+  });
+
+  it('wraps body fields in a tabs mask when tabId is provided', () => {
+    const result = buildDocumentGetFields(TABLE_INDEX_BODY_FIELDS, 't.abc123');
+    expect(result).toMatch(/^tabs\(/);
+    expect(result).toContain('tabProperties(tabId)');
+    expect(result).toContain('documentTab(');
+    expect(result).toContain(TABLE_INDEX_BODY_FIELDS);
+    // Must not contain a bare body(...) at the top level — mixing body + tabs
+    // in the same field mask causes the conflict error
+    expect(result).not.toMatch(/^body\(/);
+  });
+
+  it('produces tabs masks for all shared body field constants', () => {
+    const constants = [
+      TABLE_INDEX_BODY_FIELDS,
+      TABLE_CONTENT_BASIC_BODY_FIELDS,
+      TABLE_CONTENT_INDEXED_BODY_FIELDS,
+      HEADING_BODY_FIELDS,
+      SMART_CHIP_BODY_FIELDS,
+    ];
+
+    for (const bodyFields of constants) {
+      const withTab = buildDocumentGetFields(bodyFields, 't.abc');
+      const withoutTab = buildDocumentGetFields(bodyFields);
+
+      // With tabId: must be a tabs-only mask (no bare legacy body at root)
+      expect(withTab).toMatch(/^tabs\(/);
+      expect(withTab).not.toMatch(/^body\(/);
+
+      // Without tabId: must be a plain body mask (no tabs wrapper)
+      expect(withoutTab).toMatch(/^body\(/);
+      expect(withoutTab).not.toContain('tabs(');
     }
   });
 });

--- a/src/tools/docs/tabFieldMasks.ts
+++ b/src/tools/docs/tabFieldMasks.ts
@@ -1,8 +1,24 @@
 export const TAB_ID_PROPERTIES = 'tabProperties(tabId)';
 export const TAB_LIST_PROPERTIES = 'tabProperties(tabId,title,index,parentTabId)';
 
-export const TAB_BODY_RANGE_FIELDS = `tabs(${TAB_ID_PROPERTIES},documentTab(body(content(startIndex,endIndex))))`;
-export const TAB_BODY_END_INDEX_FIELDS = `tabs(${TAB_ID_PROPERTIES},documentTab(body(content(endIndex))))`;
+/**
+ * Builds a tabs field mask that includes childTabs recursion (3 levels deep) so that
+ * findTabById() can locate tabs nested at any depth.
+ *
+ * @param documentTabFields - the documentTab(...) subfields needed, e.g. 'documentTab(body(content(endIndex)))'
+ */
+export function buildTabsFieldMask(documentTabFields: string): string {
+  const child3 = `childTabs(${TAB_ID_PROPERTIES},${documentTabFields})`;
+  const child2 = `childTabs(${TAB_ID_PROPERTIES},${documentTabFields},${child3})`;
+  const child1 = `childTabs(${TAB_ID_PROPERTIES},${documentTabFields},${child2})`;
+  return `tabs(${TAB_ID_PROPERTIES},${documentTabFields},${child1})`;
+}
+
+const BODY_RANGE = 'documentTab(body(content(startIndex,endIndex)))';
+const BODY_END = 'documentTab(body(content(endIndex)))';
+
+export const TAB_BODY_RANGE_FIELDS = buildTabsFieldMask(BODY_RANGE);
+export const TAB_BODY_END_INDEX_FIELDS = buildTabsFieldMask(BODY_END);
 
 const TAB_LIST_CHILD_FIELDS = `childTabs(${TAB_LIST_PROPERTIES},childTabs(${TAB_LIST_PROPERTIES},childTabs(${TAB_LIST_PROPERTIES})))`;
 
@@ -15,3 +31,36 @@ export const TAB_FIELD_MASKS = {
   TAB_LIST_FIELDS,
   TAB_LIST_WITH_CONTENT_FIELDS,
 } as const;
+
+// ── Shared body-level field strings for document.get calls ──────────────────
+// Used to build conditional field masks: body fields for legacy (no tabId),
+// or buildTabsFieldMask(`documentTab(${...})`) when a tabId is provided.
+
+/** Minimal table index fields — rows/cells start+endIndex only. */
+export const TABLE_INDEX_BODY_FIELDS =
+  'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex)))))';
+
+/** Table fields with basic cell text (no content indices). */
+export const TABLE_CONTENT_BASIC_BODY_FIELDS =
+  'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))';
+
+/** Table fields with full content + element indices (needed for in-cell editing). */
+export const TABLE_CONTENT_INDEXED_BODY_FIELDS =
+  'body(content(startIndex,endIndex,table(tableRows(tableCells(startIndex,endIndex,content(startIndex,endIndex,paragraph(elements(startIndex,endIndex,textRun(content)))))))))';
+
+/** Heading + table fields for section-by-heading lookups. */
+export const HEADING_BODY_FIELDS =
+  'body(content(startIndex,endIndex,paragraph(paragraphStyle(namedStyleType),elements(textRun(content))),table(tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(textRun(content)))))))))';
+
+/** Smart chip fields (date, person, richLink) in body + table cells. */
+export const SMART_CHIP_BODY_FIELDS =
+  'body(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties))),table(tableRows(tableCells(content(paragraph(elements(startIndex,endIndex,dateElement(dateId,dateElementProperties),richLink(richLinkId,richLinkProperties),person(personId,personProperties)))))))))';
+
+/**
+ * Returns the correct fields string for a documents.get call.
+ * When tabId is set, wraps bodyFields in a tabs field mask.
+ * When tabId is absent, returns bodyFields directly (legacy body mode).
+ */
+export function buildDocumentGetFields(bodyFields: string, tabId?: string): string {
+  return tabId ? buildTabsFieldMask(`documentTab(${bodyFields})`) : bodyFields;
+}

--- a/src/tools/docs/updateSectionStyle.ts
+++ b/src/tools/docs/updateSectionStyle.ts
@@ -155,20 +155,7 @@ export function register(server: FastMCP) {
       );
       try {
         if (args.tabId) {
-          const docInfo = await docs.documents.get({
-            documentId: args.documentId,
-            includeTabsContent: true,
-            fields: 'tabs(tabProperties,documentTab(body))',
-          });
-          const targetTab = GDocsHelpers.findTabById(docInfo.data, args.tabId);
-          if (!targetTab) {
-            throw new UserError(`Tab with ID "${args.tabId}" not found in document.`);
-          }
-          if (!targetTab.documentTab) {
-            throw new UserError(
-              `Tab "${args.tabId}" does not have content (may not be a document tab).`
-            );
-          }
+          const targetTab = await GDocsHelpers.getDocumentTab(docs, args.documentId, args.tabId);
         }
 
         const built = buildUpdateSectionStyleRequest({


### PR DESCRIPTION
As per issue #137 

Ran across consistent errors when using docs tools with subtabs. Basically the fields string that was dotted throughout each tool had issues when there were subtabs, so I've moved/combined them all into a helper and fixed the underlying error. I've had Claude run each tool on each tab level, but it may be worth the reviewer doing the same before merging.

I was thinking some kind of regression test in GitHub actions may be of use but the only way I can think of doing that would be abstract the Promise that the tool executes so it can be integration tested. I.e. `server.addTool({params, execute:  PromiseFunc()})` instead of the inline pattern the repo currently uses.

One other note; I've not ran format, it resulted in 200 file changes.