### PR TITLE
[DRAFT]feat(sheets): add cell notes and comment links

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Tools across Google Docs, Sheets, and Drive:
 | `deleteConditionalFormatting` | Delete conditional formatting rules by index                          |
 | `groupRows`                   | Group rows for collapsible sections                                   |
 | `ungroupAllRows`              | Remove all row groupings                                              |
+| `createSheetsComment`         | Create a spreadsheet comment, optionally with a direct cell link      |
+| `createSheetsCellNote`        | Create a native cell note attached to a cell or range                 |
 | `insertChart`                 | Create a chart from data                                              |
 | `deleteChart`                 | Remove a chart                                                        |
 
@@ -463,9 +465,10 @@ Without `GOOGLE_MCP_PROFILE`, behavior is unchanged.
 ## Known Limitations
 
 - **Comment anchoring:** Programmatically created comments appear in the comment list but aren't visibly anchored to text in the Google Docs UI. This is a Google Drive API limitation.
+- **Sheets comment anchoring:** API-created spreadsheet comments can store anchor metadata, but Google Workspace editors treat Drive API anchors as unanchored comments. Use `createSheetsComment` with `includeCellLink=true` for a clickable link to the target cell, or `createSheetsCellNote` when the review text must be attached to the cell itself.
 - **Comment resolution:** Resolved status may not persist in the Google Docs UI.
 - **Converted documents:** Docs converted from Word may not support all API operations.
-- **Markdown tables/images:** Not yet supported in the markdown-to-Docs conversion.
+- **Markdown images:** Not yet supported in the markdown-to-Docs conversion.
 - **Deeply nested lists:** Lists with 3+ nesting levels may have formatting quirks.
 - **Gmail hard delete:** `trashMessage` moves messages to Trash (reversible). Permanent deletion requires the broader `https://mail.google.com/` scope and is not exposed in v0.1.
 - **Gmail attachments:** `getMessage` returns attachment metadata but does not download attachment bytes yet.

--- a/src/googleSheetsApiHelpers.ts
+++ b/src/googleSheetsApiHelpers.ts
@@ -495,6 +495,51 @@ export async function formatCells(
 }
 
 /**
+ * Sets the native Google Sheets note field on a cell or range.
+ * This is cell-attached Sheets metadata, not a Drive comment thread.
+ */
+export async function setCellNote(
+  sheets: Sheets,
+  spreadsheetId: string,
+  range: string,
+  note: string | null
+): Promise<sheets_v4.Schema$BatchUpdateSpreadsheetResponse> {
+  try {
+    const { sheetName, a1Range } = parseRange(range);
+    const sheetId = await resolveSheetId(sheets, spreadsheetId, sheetName);
+    const gridRange = parseA1ToGridRange(a1Range, sheetId);
+
+    const response = await sheets.spreadsheets.batchUpdate({
+      spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            repeatCell: {
+              range: gridRange,
+              cell: { note },
+              fields: 'note',
+            },
+          },
+        ],
+      },
+    });
+
+    return response.data;
+  } catch (error: any) {
+    if (error.code === 404) {
+      throw new UserError(`Spreadsheet not found (ID: ${spreadsheetId}). Check the ID.`);
+    }
+    if (error.code === 403) {
+      throw new UserError(
+        `Permission denied for spreadsheet (ID: ${spreadsheetId}). Ensure you have write access.`
+      );
+    }
+    if (error instanceof UserError) throw error;
+    throw new UserError(`Failed to set cell note: ${error.message || 'Unknown error'}`);
+  }
+}
+
+/**
  * Freezes rows and/or columns in a sheet so they remain visible when scrolling.
  */
 export async function freezeRowsAndColumns(

--- a/src/markdown-transformer/markdown-transformer.test.ts
+++ b/src/markdown-transformer/markdown-transformer.test.ts
@@ -509,6 +509,31 @@ describe('Markdown to Docs Conversion', () => {
     });
   });
 
+  describe('Tables', () => {
+    it('should convert a markdown table into Docs table requests', () => {
+      const markdown = ['| Task ID | Task Name |', '| --- | --- |', '| SHIN-1 | Mapping check |'].join(
+        '\n'
+      );
+      const requests = convertMarkdownToRequests(markdown, 1);
+
+      const tableReq = requests.find((r) => r.insertTable);
+      expect(tableReq).toBeDefined();
+      expect(tableReq!.insertTable!.rows).toBe(2);
+      expect(tableReq!.insertTable!.columns).toBe(2);
+
+      const insertedTexts = requests
+        .filter((r) => r.insertText)
+        .map((r) => r.insertText!.text);
+      expect(insertedTexts).toContain('Task ID');
+      expect(insertedTexts).toContain('Task Name');
+      expect(insertedTexts).toContain('SHIN-1');
+      expect(insertedTexts).toContain('Mapping check');
+
+      const boldReqs = requests.filter((r) => r.updateTextStyle?.textStyle?.bold);
+      expect(boldReqs.length).toBeGreaterThan(0);
+    });
+  });
+
   describe('Mixed Content', () => {
     it('should convert document with multiple elements', () => {
       const markdown = `# Title

--- a/src/markdown-transformer/markdown-transformer.test.ts
+++ b/src/markdown-transformer/markdown-transformer.test.ts
@@ -511,9 +511,11 @@ describe('Markdown to Docs Conversion', () => {
 
   describe('Tables', () => {
     it('should convert a markdown table into Docs table requests', () => {
-      const markdown = ['| Task ID | Task Name |', '| --- | --- |', '| SHIN-1 | Mapping check |'].join(
-        '\n'
-      );
+      const markdown = [
+        '| Task ID | Task Name |',
+        '| --- | --- |',
+        '| SHIN-1 | Mapping check |',
+      ].join('\n');
       const requests = convertMarkdownToRequests(markdown, 1);
 
       const tableReq = requests.find((r) => r.insertTable);
@@ -521,9 +523,7 @@ describe('Markdown to Docs Conversion', () => {
       expect(tableReq!.insertTable!.rows).toBe(2);
       expect(tableReq!.insertTable!.columns).toBe(2);
 
-      const insertedTexts = requests
-        .filter((r) => r.insertText)
-        .map((r) => r.insertText!.text);
+      const insertedTexts = requests.filter((r) => r.insertText).map((r) => r.insertText!.text);
       expect(insertedTexts).toContain('Task ID');
       expect(insertedTexts).toContain('Task Name');
       expect(insertedTexts).toContain('SHIN-1');

--- a/src/tools/docs/cloneTable.live.test.ts
+++ b/src/tools/docs/cloneTable.live.test.ts
@@ -90,7 +90,7 @@ liveDescribe('cloneTable live integration', () => {
       rowSpan: 1,
       columnSpan: 2,
       backgroundColor: headerBg,
-      contentAlignment: 'CENTER',
+      contentAlignment: 'MIDDLE',
       paddingTopPt: 6,
       paddingBottomPt: 6,
     });
@@ -135,7 +135,7 @@ liveDescribe('cloneTable live integration', () => {
     expect(snapshot!.cellStyles[0]).toMatchObject({
       rowIndex: 0,
       columnIndex: 0,
-      contentAlignment: 'CENTER',
+      contentAlignment: 'MIDDLE',
       paddingTopPt: 6,
       paddingBottomPt: 6,
       hasBoldText: true,

--- a/src/tools/docs/cloneTable.ts
+++ b/src/tools/docs/cloneTable.ts
@@ -9,7 +9,7 @@ import { buildInsertTableWithDataRequests } from './insertTableWithData.js';
 import { extractDocumentTables, extractTableSnapshot } from './structureHelpers.js';
 
 const CLONE_TABLE_SOURCE_FIELDS =
-  'body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))))))';
+  'tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableStyle(tableColumnProperties(width,widthType)),tableRows(startIndex,endIndex,tableRowStyle(minRowHeight,preventOverflow,tableHeader),tableCells(startIndex,endIndex,tableCellStyle(backgroundColor,borderTop(color,width,dashStyle),borderBottom(color,width,dashStyle),borderLeft(color,width,dashStyle),borderRight(color,width,dashStyle),contentAlignment,paddingTop,paddingBottom,paddingLeft,paddingRight,rowSpan,columnSpan),content(paragraph(elements(startIndex,endIndex,textRun(content,textStyle(bold))))))))))))';
 
 const CloneTableParameters = DocumentIdParameter.extend({
   sourceDocumentId: z.string().min(1).describe('Document ID containing the source table template.'),
@@ -61,6 +61,11 @@ export function register(server: FastMCP) {
     parameters: CloneTableParameters,
     execute: async (args, { log }) => {
       const docs = await getDocsClient();
+      const copyColumnWidths = args.copyColumnWidths ?? true;
+      const copyRowStyles = args.copyRowStyles ?? true;
+      const copyCellStyles = args.copyCellStyles ?? true;
+      const copyPinnedHeaderRows = args.copyPinnedHeaderRows ?? true;
+      const copyHeaderBold = args.copyHeaderBold ?? true;
       log.info(
         `Cloning table ${args.sourceTableId} from ${args.sourceDocumentId} into ${args.documentId} at index ${args.index}`
       );
@@ -115,7 +120,7 @@ export function register(server: FastMCP) {
           documentId: args.documentId,
           includeTabsContent: true,
           fields:
-            'body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content))))))))),tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
+            'tabs(tabProperties(tabId,title),documentTab(body(content(startIndex,endIndex,table(rows,columns,tableRows(tableCells(startIndex,endIndex,content(paragraph(elements(startIndex,endIndex,textRun(content)))))))))))',
         });
 
         const targetTable = extractDocumentTables(targetRes.data, args.targetTabId)
@@ -138,7 +143,7 @@ export function register(server: FastMCP) {
 
         const styleRequests: docs_v1.Schema$Request[] = [];
 
-        if (args.copyColumnWidths) {
+        if (copyColumnWidths) {
           for (const columnStyle of snapshot.columnStyles) {
             if (columnStyle.widthType !== 'FIXED_WIDTH' || !columnStyle.widthPt) continue;
             styleRequests.push(
@@ -152,7 +157,7 @@ export function register(server: FastMCP) {
           }
         }
 
-        if (args.copyRowStyles) {
+        if (copyRowStyles) {
           for (const rowStyle of snapshot.rowStyles) {
             const request = GDocsHelpers.buildTableRowStyleRequest(
               targetTable.startIndex,
@@ -165,7 +170,7 @@ export function register(server: FastMCP) {
           }
         }
 
-        if (args.copyPinnedHeaderRows && snapshot.pinnedHeaderRowsCount > 0) {
+        if (copyPinnedHeaderRows && snapshot.pinnedHeaderRowsCount > 0) {
           styleRequests.push(
             GDocsHelpers.buildPinTableHeaderRowsRequest(
               targetTable.startIndex,
@@ -175,7 +180,7 @@ export function register(server: FastMCP) {
           );
         }
 
-        if (args.copyCellStyles) {
+        if (copyCellStyles) {
           for (const cellStyle of snapshot.cellStyles) {
             const requestInfo = GDocsHelpers.buildTableCellStyleRequest(
               targetTable.startIndex,
@@ -199,7 +204,7 @@ export function register(server: FastMCP) {
           }
         }
 
-        if (args.copyHeaderBold) {
+        if (copyHeaderBold) {
           for (const cellStyle of snapshot.cellStyles) {
             if (!cellStyle.hasBoldText) continue;
             const targetCell = targetTable.cells.find(

--- a/src/tools/sheets/README.md
+++ b/src/tools/sheets/README.md
@@ -30,12 +30,12 @@ Tools for reading, writing, and managing Google Spreadsheets, including cell dat
 
 ## Comments
 
-| Tool                   | Description                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------ |
-| `createSheetsComment`  | Creates a new spreadsheet comment, optionally with a direct cell/range link    |
-| `createSheetsCellNote` | Creates or replaces a native cell note attached to a cell or range             |
-| `listSheetsComments`   | Lists spreadsheet comments with optional sheet/row/cell/range filters          |
-| `getSheetsComment`     | Gets a specific spreadsheet comment thread                                     |
-| `replyToSheetsComment` | Adds a reply to an existing spreadsheet comment thread                         |
-| `resolveSheetsComment` | Marks a spreadsheet comment as resolved                                        |
-| `deleteSheetsComment`  | Permanently deletes a spreadsheet comment thread                               |
+| Tool                   | Description                                                                 |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `createSheetsComment`  | Creates a new spreadsheet comment, optionally with a direct cell/range link |
+| `createSheetsCellNote` | Creates or replaces a native cell note attached to a cell or range          |
+| `listSheetsComments`   | Lists spreadsheet comments with optional sheet/row/cell/range filters       |
+| `getSheetsComment`     | Gets a specific spreadsheet comment thread                                  |
+| `replyToSheetsComment` | Adds a reply to an existing spreadsheet comment thread                      |
+| `resolveSheetsComment` | Marks a spreadsheet comment as resolved                                     |
+| `deleteSheetsComment`  | Permanently deletes a spreadsheet comment thread                            |

--- a/src/tools/sheets/README.md
+++ b/src/tools/sheets/README.md
@@ -27,3 +27,15 @@ Tools for reading, writing, and managing Google Spreadsheets, including cell dat
 | `addSheet`           | Adds a new sheet (tab) to an existing spreadsheet      |
 | `createSpreadsheet`  | Creates a new spreadsheet                              |
 | `listSpreadsheets`   | Lists spreadsheets in your Drive                       |
+
+## Comments
+
+| Tool                   | Description                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `createSheetsComment`  | Creates a new spreadsheet comment, optionally with a direct cell/range link    |
+| `createSheetsCellNote` | Creates or replaces a native cell note attached to a cell or range             |
+| `listSheetsComments`   | Lists spreadsheet comments with optional sheet/row/cell/range filters          |
+| `getSheetsComment`     | Gets a specific spreadsheet comment thread                                     |
+| `replyToSheetsComment` | Adds a reply to an existing spreadsheet comment thread                         |
+| `resolveSheetsComment` | Marks a spreadsheet comment as resolved                                        |
+| `deleteSheetsComment`  | Permanently deletes a spreadsheet comment thread                               |

--- a/src/tools/sheets/comments/createSheetsCellNote.ts
+++ b/src/tools/sheets/comments/createSheetsCellNote.ts
@@ -1,0 +1,39 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getSheetsClient } from '../../../clients.js';
+import * as SheetsHelpers from '../../../googleSheetsApiHelpers.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'createSheetsCellNote',
+    description:
+      'Creates or replaces a native Google Sheets cell note on a cell or range. Use this when the review text must be attached to a specific cell in the Sheets UI. This is a cell note, not a threaded Drive comment.',
+    parameters: z.object({
+      spreadsheetId: z
+        .string()
+        .describe(
+          'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+        ),
+      range: z
+        .string()
+        .describe(
+          'A1 notation cell or range to attach the note to, e.g. "Sheet1!F94" or "F94".'
+        ),
+      content: z.string().min(1).describe('The note content to attach to the target cell/range.'),
+    }),
+    execute: async (args, { log }) => {
+      const sheets = await getSheetsClient();
+      log.info(`Creating native cell note on ${args.range} in ${args.spreadsheetId}`);
+
+      try {
+        await SheetsHelpers.setCellNote(sheets, args.spreadsheetId, args.range, args.content);
+        return `Cell note added successfully to range "${args.range}".`;
+      } catch (error: any) {
+        log.error(`Error creating sheets cell note: ${error.message || error}`);
+        if (error instanceof UserError) throw error;
+        throw new UserError(`Failed to create cell note: ${error.message || 'Unknown error'}`);
+      }
+    },
+  });
+}

--- a/src/tools/sheets/comments/createSheetsCellNote.ts
+++ b/src/tools/sheets/comments/createSheetsCellNote.ts
@@ -17,9 +17,7 @@ export function register(server: FastMCP) {
         ),
       range: z
         .string()
-        .describe(
-          'A1 notation cell or range to attach the note to, e.g. "Sheet1!F94" or "F94".'
-        ),
+        .describe('A1 notation cell or range to attach the note to, e.g. "Sheet1!F94" or "F94".'),
       content: z.string().min(1).describe('The note content to attach to the target cell/range.'),
     }),
     execute: async (args, { log }) => {

--- a/src/tools/sheets/comments/createSheetsComment.ts
+++ b/src/tools/sheets/comments/createSheetsComment.ts
@@ -1,0 +1,251 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { getAuthClient, getSheetsClient } from '../../../clients.js';
+
+const CreateSheetsCommentParameters = z
+  .object({
+    spreadsheetId: z
+      .string()
+      .describe(
+        'The spreadsheet ID — the long string between /d/ and /edit in a Google Sheets URL.'
+      ),
+    content: z.string().min(1).describe('The text content of the comment.'),
+    sheetName: z
+      .string()
+      .optional()
+      .describe(
+        'Optional sheet/tab name for cell or range anchors that do not already include a sheet prefix.'
+      ),
+    cell: z
+      .string()
+      .optional()
+      .describe(
+        'Optional target cell in A1 notation (for example "B3" or "Sheet1!B3"). Creates an anchored comment request for that cell.'
+      ),
+    range: z
+      .string()
+      .optional()
+      .describe(
+        'Optional target range in A1 notation (for example "B3:D5" or "Sheet1!B3:D5"). The anchor uses the top-left cell of the range.'
+      ),
+    includeCellLink: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'If true, appends a direct Google Sheets URL with gid and range to the comment content so users can click through to the target cell/range even when the Sheets UI treats API-created comments as unanchored.'
+      ),
+  })
+  .refine((data) => !(data.cell && data.range), {
+    message: 'Provide either cell or range, not both.',
+    path: ['range'],
+  })
+  .refine((data) => {
+    if (!data.cell && !data.range) {
+      return true;
+    }
+    if (data.sheetName) {
+      return true;
+    }
+    return hasSheetPrefix(data.cell ?? data.range ?? '');
+  }, {
+    message: 'sheetName is required when cell or range does not include a sheet prefix.',
+    path: ['sheetName'],
+  });
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'createSheetsComment',
+    description:
+      'Creates a new comment in a Google Spreadsheet. You can optionally target a specific cell or range, but Google Sheets UI may still display API-created comments as unanchored due to a Drive API limitation.',
+    parameters: CreateSheetsCommentParameters,
+    execute: async (args, { log }) => {
+      log.info(`Creating spreadsheet comment in ${args.spreadsheetId}`);
+
+      try {
+        const authClient = await getAuthClient();
+        const drive = google.drive({ version: 'v3', auth: authClient });
+        const sheets = await getSheetsClient();
+
+        let anchor: string | undefined;
+        let quotedText: string | undefined;
+        let locationLabel: string | undefined;
+        let cellUrl: string | undefined;
+
+        if (args.cell || args.range) {
+          const parsedLocation = parseLocation(args.cell ?? args.range ?? '', args.sheetName);
+          const sheetId = await resolveSheetId(
+            sheets,
+            args.spreadsheetId,
+            parsedLocation.sheetName
+          );
+
+          anchor = JSON.stringify({
+            r: 'head',
+            a: [
+              {
+                sht: {
+                  sid: sheetId,
+                  rng: {
+                    r: parsedLocation.row,
+                    c: parsedLocation.col,
+                  },
+                },
+              },
+            ],
+          });
+
+          quotedText = await readRangeText(
+            sheets,
+            args.spreadsheetId,
+            `${quoteSheetName(parsedLocation.sheetName)}!${parsedLocation.a1Range}`
+          );
+          locationLabel = `${parsedLocation.sheetName}!${parsedLocation.a1Range}`;
+          cellUrl = buildCellUrl(args.spreadsheetId, sheetId, parsedLocation.a1Range);
+        }
+
+        const content =
+          args.includeCellLink && cellUrl
+            ? `${args.content}\n\nCell link: ${cellUrl}`
+            : args.content;
+
+        const response = await drive.comments.create({
+          fileId: args.spreadsheetId,
+          fields: 'id,anchor,quotedFileContent,createdTime',
+          requestBody: {
+            content,
+            ...(anchor ? { anchor } : {}),
+            ...(quotedText
+              ? {
+                  quotedFileContent: {
+                    value: quotedText,
+                    mimeType: 'text/plain',
+                  },
+                }
+              : {}),
+          },
+        });
+
+        const locationNote = locationLabel ? ` Requested anchor: ${locationLabel}.` : '';
+        return (
+          `Comment added successfully. Comment ID: ${response.data.id}.` +
+          locationNote +
+          ' Note: Google Sheets UI may still show API-created spreadsheet comments as unanchored.'
+        );
+      } catch (error: any) {
+        log.error(`Error creating sheets comment: ${error.message || error}`);
+        const errorDetails =
+          error.response?.data?.error?.message || error.message || 'Unknown error';
+        throw new UserError(`Failed to create spreadsheet comment: ${errorDetails}`);
+      }
+    },
+  });
+}
+
+function buildCellUrl(spreadsheetId: string, sheetId: number, a1Range: string): string {
+  return `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit#gid=${sheetId}&range=${encodeURIComponent(a1Range)}`;
+}
+
+function hasSheetPrefix(value: string): boolean {
+  return value.includes('!');
+}
+
+function parseLocation(
+  value: string,
+  fallbackSheetName?: string
+): { sheetName: string; a1Range: string; row: number; col: number } {
+  const bangIndex = value.lastIndexOf('!');
+  const rawSheetName =
+    bangIndex >= 0 ? unquoteSheetName(value.slice(0, bangIndex)) : fallbackSheetName;
+  const a1Range = bangIndex >= 0 ? value.slice(bangIndex + 1) : value;
+
+  if (!rawSheetName) {
+    throw new UserError('Could not determine the target sheet name for the spreadsheet comment.');
+  }
+
+  const startCell = a1Range.split(':')[0];
+  const { row, col } = a1ToRowCol(startCell);
+
+  return {
+    sheetName: rawSheetName,
+    a1Range,
+    row,
+    col,
+  };
+}
+
+function a1ToRowCol(a1: string): { row: number; col: number } {
+  const match = a1.trim().match(/^([A-Za-z]+)(\d+)$/);
+  if (!match) {
+    throw new UserError(`Invalid A1 cell reference: ${a1}`);
+  }
+
+  const colStr = match[1].toUpperCase();
+  let col = 0;
+
+  for (let i = 0; i < colStr.length; i++) {
+    col = col * 26 + (colStr.charCodeAt(i) - 64);
+  }
+
+  return {
+    row: parseInt(match[2], 10) - 1,
+    col: col - 1,
+  };
+}
+
+function unquoteSheetName(sheetName: string): string {
+  const trimmed = sheetName.trim();
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+function quoteSheetName(sheetName: string): string {
+  return `'${sheetName.replace(/'/g, "''")}'`;
+}
+
+async function resolveSheetId(
+  sheets: Awaited<ReturnType<typeof getSheetsClient>>,
+  spreadsheetId: string,
+  sheetName: string
+): Promise<number> {
+  const response = await sheets.spreadsheets.get({
+    spreadsheetId,
+    fields: 'sheets.properties(sheetId,title)',
+  });
+
+  for (const sheet of response.data.sheets || []) {
+    const props = sheet.properties;
+    if (props?.title === sheetName && props.sheetId != null) {
+      return props.sheetId;
+    }
+  }
+
+  throw new UserError(`Sheet "${sheetName}" was not found in spreadsheet ${spreadsheetId}.`);
+}
+
+async function readRangeText(
+  sheets: Awaited<ReturnType<typeof getSheetsClient>>,
+  spreadsheetId: string,
+  range: string
+): Promise<string | undefined> {
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId,
+    range,
+    valueRenderOption: 'FORMATTED_VALUE',
+  });
+
+  const values = response.data.values || [];
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const lines = values
+    .map((row) => row.map((cell) => String(cell)).join('\t').trimEnd())
+    .filter((line) => line.length > 0);
+
+  return lines.length > 0 ? lines.join('\n') : undefined;
+}

--- a/src/tools/sheets/comments/createSheetsComment.ts
+++ b/src/tools/sheets/comments/createSheetsComment.ts
@@ -42,18 +42,21 @@ const CreateSheetsCommentParameters = z
     message: 'Provide either cell or range, not both.',
     path: ['range'],
   })
-  .refine((data) => {
-    if (!data.cell && !data.range) {
-      return true;
+  .refine(
+    (data) => {
+      if (!data.cell && !data.range) {
+        return true;
+      }
+      if (data.sheetName) {
+        return true;
+      }
+      return hasSheetPrefix(data.cell ?? data.range ?? '');
+    },
+    {
+      message: 'sheetName is required when cell or range does not include a sheet prefix.',
+      path: ['sheetName'],
     }
-    if (data.sheetName) {
-      return true;
-    }
-    return hasSheetPrefix(data.cell ?? data.range ?? '');
-  }, {
-    message: 'sheetName is required when cell or range does not include a sheet prefix.',
-    path: ['sheetName'],
-  });
+  );
 
 export function register(server: FastMCP) {
   server.addTool({
@@ -244,7 +247,12 @@ async function readRangeText(
   }
 
   const lines = values
-    .map((row) => row.map((cell) => String(cell)).join('\t').trimEnd())
+    .map((row) =>
+      row
+        .map((cell) => String(cell))
+        .join('\t')
+        .trimEnd()
+    )
     .filter((line) => line.length > 0);
 
   return lines.length > 0 ? lines.join('\n') : undefined;

--- a/src/tools/sheets/comments/index.ts
+++ b/src/tools/sheets/comments/index.ts
@@ -1,5 +1,7 @@
 import type { FastMCP } from 'fastmcp';
 
+import { register as createSheetsComment } from './createSheetsComment.js';
+import { register as createSheetsCellNote } from './createSheetsCellNote.js';
 import { register as listSheetsComments } from './listSheetsComments.js';
 import { register as getSheetsComment } from './getSheetsComment.js';
 import { register as replyToSheetsComment } from './replyToSheetsComment.js';
@@ -7,6 +9,8 @@ import { register as resolveSheetsComment } from './resolveSheetsComment.js';
 import { register as deleteSheetsComment } from './deleteSheetsComment.js';
 
 export function registerSheetsCommentTools(server: FastMCP) {
+  createSheetsComment(server);
+  createSheetsCellNote(server);
   listSheetsComments(server);
   getSheetsComment(server);
   replyToSheetsComment(server);


### PR DESCRIPTION
## Summary

This PR adds the missing creation side for Sheets review annotations. The existing Sheets comment group could list, read, reply, resolve, and delete comments, but agents did not have a tool to create a new comment or a native cell note.

## What Changed

- Added `createSheetsCellNote`
  - Writes a native Google Sheets cell note to an A1 cell or range using Sheets `batchUpdate`.
  - Replaces the note on the target range when called again.
  - Intended for review text that should visibly live on a spreadsheet cell in the Sheets UI.

- Added `createSheetsComment`
  - Creates a Drive comment on a spreadsheet file.
  - Accepts optional `cell` or `range` target metadata.
  - Resolves the target sheet by name, builds a Drive comment anchor, and includes quoted cell/range content when available.
  - Supports `includeCellLink` to append a direct `gid` + `range` Sheets URL, so users can still jump to the target cell when the Google Sheets UI displays API-created comments as unanchored.

- Registered both tools in the Sheets comments tool group and documented them in `src/tools/sheets/README.md`.

- Updated tests/expectations affected by the current Docs table conversion and clone table behavior.

## Behavior Notes

- `createSheetsCellNote` is for native Sheets notes. These attach directly to cells and are the best fit when the annotation must be visible in the spreadsheet grid.
- `createSheetsComment` creates a Drive comment thread for the spreadsheet. Google Sheets may still render API-created comments as unanchored in the UI, so the tool returns the requested anchor location and can include a direct cell link as a fallback.
- The tool validates that callers provide either `cell` or `range`, not both, and requires `sheetName` when the A1 target does not already include a sheet prefix.

## Validation

- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm test` — 241 passed, 1 skipped