### PR TITLE
LOV-61: upgrade fastmcp to v4.0.1 to fix OAuth POST 404 in remote mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/firestore": "^8.3.0",
-        "fastmcp": "^3.34.0",
+        "fastmcp": "^4.0.1",
         "google-auth-library": "^10.5.0",
         "googleapis": "^171.4.0",
         "markdown-it": "^14.1.0",
@@ -1527,9 +1527,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -2147,6 +2147,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2232,9 +2233,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastmcp": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.34.0.tgz",
-      "integrity": "sha512-xKOXjU+MK7OZy91BY3FS5aenSiclJBCRMaZtXb3HYaKZVFbq4qYvAlFu6xYI3UU1NGLtv+h8izoStnOQ1By0BA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-4.0.1.tgz",
+      "integrity": "sha512-ZNTCxyKJT/3WVR7iZ5PI7+WNj6Hba+Hzbc18h5GhggKaWyrTDHPNikGvPY/idC2gbEITJWuZRaUNbssbSPfBUw==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
@@ -2243,7 +2244,7 @@
         "file-type": "^21.1.1",
         "fuse.js": "^7.1.0",
         "hono": "^4.11.5",
-        "mcp-proxy": "^6.4.0",
+        "mcp-proxy": "^6.4.6",
         "strict-event-emitter-types": "^2.0.0",
         "undici": "^7.16.0",
         "uri-templates": "^0.2.0",
@@ -2549,9 +2550,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2794,6 +2795,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
       "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3102,9 +3104,9 @@
       "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/koa": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.2.tgz",
-      "integrity": "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.8",
@@ -3268,9 +3270,9 @@
       }
     },
     "node_modules/mcp-proxy": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.4.4.tgz",
-      "integrity": "sha512-8L61e0yk/1S6pe0DkeWXDNRkb8m5yoa6ZouLpe9uOes/pkcjgYvLhfVnO7zjZUTD5R3/GljAI+KizaYBNrypBg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.1.tgz",
+      "integrity": "sha512-N/V131Y269ns9oM2/AUMnjAcghsMEENYt0E3B+Ehc5uRVMpBX3p4tsncvQIkN2EzTE5feoQetN+qQq/4HrCa0g==",
       "license": "MIT",
       "dependencies": {
         "pipenet": "^1.3.0"
@@ -3599,6 +3601,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3607,9 +3610,9 @@
       }
     },
     "node_modules/pipenet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.0.tgz",
-      "integrity": "sha512-Uc3EH2i8hnJUD0Eupj9z2jaZPjjAbooaiHGh0iFdExbE8/BDt6Lf0919Dtwx5VM83elHNWFzCOsvzsViTD5YZg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
       "dependencies": {
         "axios": "^1.7.3",
         "debug": "^4.3.6",
@@ -4448,6 +4451,7 @@
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -4577,6 +4581,7 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a-bonus/google-docs-mcp",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "type": "module",
   "bin": {
     "google-docs-mcp": "dist/index.js"
@@ -33,7 +33,7 @@
   "description": "MCP server for Google Docs, Sheets, Drive, Gmail, and Calendar",
   "dependencies": {
     "@google-cloud/firestore": "^8.3.0",
-    "fastmcp": "^3.34.0",
+    "fastmcp": "^4.0.1",
     "google-auth-library": "^10.5.0",
     "googleapis": "^171.4.0",
     "markdown-it": "^14.1.0",


### PR DESCRIPTION
## Summary

- Upgrade `fastmcp` from `^3.34.0` to `^4.0.1` to fix OAuth POST 404 in remote deployments
- Bump package version `1.10.1` → `1.11.0`

## Problem

`mcp-proxy` 6.x (used by FastMCP 3.30+) called `onUnhandledRequest` before MCP handlers, consuming POST request bodies via Hono's web Request wrapper. This caused `/oauth/register`, `/oauth/token`, and `/oauth/consent` to return 404 on Cloud Run.

## Fix

FastMCP v4.0.1 depends on `mcp-proxy` ≥6.4.6 where the handler ordering is corrected. No application-level workaround needed.

### Upstream references
- [punkpeye/fastmcp#260](https://github.com/punkpeye/fastmcp/issues/260)
- [punkpeye/mcp-proxy#61](https://github.com/punkpeye/mcp-proxy/issues/61)
- Fixed in [fastmcp v4.0.1](https://github.com/punkpeye/fastmcp/releases/tag/v4.0.1)

## Test plan

- [x] Deployed to Google Cloud Run
- [x] `POST /oauth/register` → 201
- [x] `POST /oauth/token` → 400 (correctly rejects fake code)
- [x] `POST /mcp` → 401 (auth gate working)
- [x] `GET /.well-known/*` → 200
- [x] Full OAuth flow verified end-to-end

## Linear

[LOV-61](https://linear.app/primary-os/issue/LOV-61/upgrade-fastmcp-to-v401-and-fix-persistent-oauth-sessions)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)