### PR TITLE
feat: add MCP_STATELESS env var for serverless deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Visit the server root URL (`/`) for setup instructions and a ready-to-copy clien
 | `JWT_SIGNING_KEY`      | Fixed signing key so tokens survive restarts (auto-generated if not set)                                            |
 | `REFRESH_TOKEN_TTL`    | Refresh token lifetime in seconds (default: `2592000` / 30 days)                                                    |
 | `GCLOUD_PROJECT`       | GCP project ID for Firestore (required when `TOKEN_STORE=firestore`)                                                |
+| `MCP_STATELESS`        | Set to `true` for serverless deployments (Cloud Run, etc.) — disables session tracking to survive scale-to-zero     |
 
 ### Setup
 
@@ -355,6 +356,7 @@ gcloud run deploy google-docs-mcp \
 
 - By default, OAuth sessions are stored in memory and lost on restart
 - For production, set `TOKEN_STORE=firestore` and `JWT_SIGNING_KEY` for persistent auth across deploys and cold starts
+- On serverless platforms (Cloud Run, etc.), set `MCP_STATELESS=true` — MCP sessions are held in memory, so scale-to-zero wipes them. Stateless mode disables session tracking entirely; each request authenticates independently via the JWT/Firestore token flow
 - `ALLOWED_DOMAINS` restricts access to specific Google Workspace domains
 - Access tokens refresh automatically; inactive sessions expire after 30 days
 - Users can revoke access at any time via [Google Account permissions](https://myaccount.google.com/permissions)

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseStatelessFlag } from './config.js';
+
+describe('parseStatelessFlag', () => {
+  it('defaults to false when no value is provided', () => {
+    expect(parseStatelessFlag(undefined)).toBe(false);
+    expect(parseStatelessFlag('')).toBe(false);
+    expect(parseStatelessFlag('  ')).toBe(false);
+  });
+
+  it('returns true for "true" (case-insensitive)', () => {
+    expect(parseStatelessFlag('true')).toBe(true);
+    expect(parseStatelessFlag('TRUE')).toBe(true);
+    expect(parseStatelessFlag('True')).toBe(true);
+    expect(parseStatelessFlag(' true ')).toBe(true);
+  });
+
+  it('returns true for "1"', () => {
+    expect(parseStatelessFlag('1')).toBe(true);
+  });
+
+  it('returns false for other values', () => {
+    expect(parseStatelessFlag('false')).toBe(false);
+    expect(parseStatelessFlag('0')).toBe(false);
+    expect(parseStatelessFlag('yes')).toBe(false);
+    expect(parseStatelessFlag('stateless')).toBe(false);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,9 @@
+/**
+ * Parses MCP_STATELESS env var. Stateless mode disables httpStream session
+ * tracking so the server survives serverless scale-to-zero without losing
+ * MCP sessions.
+ */
+export function parseStatelessFlag(value?: string): boolean {
+  const raw = (value ?? process.env.MCP_STATELESS ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { wrapServerForRemote } from './remoteWrapper.js';
 import { registerLandingPage } from './landingPage.js';
 import { registerDownloadRoute } from './downloadProxy.js';
 import { FirestoreTokenStorage } from './firestoreTokenStorage.js';
+import { parseStatelessFlag } from './config.js';
 import { logger } from './logger.js';
 
 // --- Auth subcommand ---
@@ -218,6 +219,7 @@ try {
       httpStream: {
         port,
         host: '0.0.0.0',
+        stateless: parseStatelessFlag(),
       },
     });
 


### PR DESCRIPTION
## Summary

Adds a `MCP_STATELESS` environment variable that enables FastMCP's stateless httpStream mode, fixing session loss on serverless platforms like Cloud Run.

## Problem

MCP sessions are stored in an in-memory JS object (`activeTransports`) inside mcp-proxy. On serverless platforms, instances scale to zero when idle and restart on the next request — wiping all sessions. Clients reconnecting with a stale `Mcp-Session-Id` receive HTTP 404 "Session not found."

The MCP spec says clients [MUST re-initialize on 404](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports), but major clients don't:
- **Claude Code**: [anthropics/claude-code#60949](https://github.com/anthropics/claude-code/issues/60949) — closed "not planned"
- **VS Code**: [microsoft/vscode#253854](https://github.com/microsoft/vscode/issues/253854) — still open

Users see a dead connection after idle periods (weekends, overnight) and must manually reconnect.

## Solution

Set `MCP_STATELESS=true` to enable stateless mode. Each request creates a temporary ephemeral session — no session IDs are tracked, stale headers are ignored. Auth still runs per-request via the JWT + Firestore token flow.

- **Default**: `false` (existing behavior unchanged)
- **Accepts**: `true`, `1` (case-insensitive)
- **Tradeoff**: No server-to-client push notifications (SSE). The server is purely request-response so nothing is lost.

## Changes

- `src/config.ts` — new `parseStatelessFlag()` helper
- `src/config.test.ts` — 4 tests for env var parsing
- `src/index.ts` — import and pass `stateless: parseStatelessFlag()` to httpStream config
- `README.md` — document `MCP_STATELESS` in env var table and "How It Works" section

## Test plan

- [x] `npm run format:check` passes
- [x] `npx tsc --noEmit` passes
- [x] All 266 tests pass (4 new)
- [x] Tested locally: stale session ID returns 200 (stateless) vs 404 (stateful)
- [x] Deployed to Cloud Run with `MCP_STATELESS=true` — connections survive scale-to-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)