### PR TITLE
fix: request Google offline access so remote OAuth issues a refresh token [PRI-874]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a-bonus/google-docs-mcp",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "bin": {
     "google-docs-mcp": "dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,9 @@ if (isRemote) {
   const missing = ['BASE_URL', 'GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'].filter(
     (k) => !process.env[k]
   );
+  if (process.env.TOKEN_STORE === 'firestore' && !process.env.GCLOUD_PROJECT) {
+    missing.push('GCLOUD_PROJECT');
+  }
   if (missing.length > 0) {
     logger.error(`FATAL: Missing required env vars for httpStream mode: ${missing.join(', ')}`);
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { registerLandingPage } from './landingPage.js';
 import { registerDownloadRoute } from './downloadProxy.js';
 import { FirestoreTokenStorage } from './firestoreTokenStorage.js';
 import { parseStatelessFlag } from './config.js';
+import { enableUpstreamOfflineAccess } from './upstreamAuth.js';
 import { logger } from './logger.js';
 
 // --- Auth subcommand ---
@@ -160,6 +161,13 @@ if (oauthProxy) {
     }
     return origIssue(clientId, upstreamTokens);
   };
+
+  // Request Google offline access so the upstream token exchange returns a
+  // refresh_token. Without it, the stored Google access token (1-hour TTL)
+  // can never be renewed and every API call fails ~1 hour after a user
+  // authenticates. With a refresh_token present, google-auth-library
+  // auto-refreshes on 401 (see remoteWrapper.createClients / upstreamAuth.ts).
+  enableUpstreamOfflineAccess(oauthProxy);
 }
 
 const server = new FastMCP({

--- a/src/oauthRefresh.repro.test.ts
+++ b/src/oauthRefresh.repro.test.ts
@@ -1,0 +1,125 @@
+// Reproduction of the production OAuth bug on production-equivalent code.
+//
+// Bug: the remote OAuthProxy never requests Google "offline access", so Google
+// returns no refresh_token. The stored Google access token (1-hour TTL) is then
+// never renewed, and every Google API call fails ~1 hour after a user
+// authenticates.
+//
+// This file is written to PASS on the un-fixed (synced) code: it documents the
+// broken behavior (root cause) and proves the runtime consequence with the real
+// `createClients` against a mock Google. The fix is verified separately in
+// upstreamAuth.test.ts (the patched OAuthProxy DOES request offline access).
+//
+// The two layers below are independent of the fix module, so they run against
+// production-equivalent code with no fix present.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { OAuthProxy } from 'fastmcp/auth';
+import { createClients } from './remoteWrapper.js';
+
+// Mirrors the OAuthProxy configuration in src/index.ts (remote mode).
+function buildProductionProxy(): OAuthProxy {
+  return new OAuthProxy({
+    upstreamAuthorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+    upstreamTokenEndpoint: 'https://oauth2.googleapis.com/token',
+    upstreamClientId: 'test-client-id',
+    upstreamClientSecret: 'test-secret',
+    baseUrl: 'https://example.com',
+    scopes: ['openid', 'email'],
+    allowedRedirectUriPatterns: ['https://example.com/*'],
+    jwtSigningKey: '0'.repeat(64),
+    encryptionKey: '0'.repeat(64),
+    consentRequired: false,
+  });
+}
+
+describe('ROOT CAUSE: remote OAuthProxy authorization URL (unpatched)', () => {
+  it('does NOT request offline access, so Google returns no refresh_token', () => {
+    const proxy = buildProductionProxy();
+    const response = (
+      proxy as unknown as { redirectToUpstream: (t: unknown) => Response }
+    ).redirectToUpstream({
+      id: 'txn-1',
+      scope: ['openid', 'email'],
+      proxyCodeChallenge: 'challenge',
+    });
+    const url = new URL(response.headers.get('Location')!);
+
+    // This is the bug: no access_type=offline => no refresh_token from Google.
+    expect(url.searchParams.get('access_type')).toBeNull();
+    expect(url.searchParams.get('prompt')).toBeNull();
+  });
+});
+
+describe('CONSEQUENCE: an expired Google access token (real createClients vs mock Google)', () => {
+  let server: http.Server;
+  let base: string;
+  let tokenEndpointHits = 0;
+
+  beforeAll(async () => {
+    process.env.GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || 'test-secret';
+
+    server = http.createServer((req, res) => {
+      // Mock Google token endpoint: exchanges a refresh_token for a fresh access token.
+      if (req.method === 'POST' && req.url === '/token') {
+        tokenEndpointHits++;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            access_token: 'FRESH_ACCESS_TOKEN',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          })
+        );
+        return;
+      }
+      // Mock Google API: 200 only when presented a fresh token, else 401 (expired).
+      if (req.url?.startsWith('/api')) {
+        const auth = req.headers['authorization'] ?? '';
+        if (auth.includes('FRESH_ACCESS_TOKEN')) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+        } else {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: { code: 401, message: 'Invalid Credentials' } }));
+        }
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('REPRODUCES the outage: with NO refresh_token, an expired token is never renewed and the call fails', async () => {
+    tokenEndpointHits = 0;
+    const clients = createClients('EXPIRED_STALE_TOKEN'); // no refresh token — current prod reality
+    (
+      clients.auth as unknown as { endpoints: { oauth2TokenUrl: string } }
+    ).endpoints.oauth2TokenUrl = `${base}/token`;
+
+    await expect(clients.auth.request({ url: `${base}/api`, method: 'GET' })).rejects.toThrow();
+    expect(tokenEndpointHits).toBe(0); // no refresh was even attempted
+  });
+
+  it('FIX PREMISE: with a refresh_token present, the same expired token auto-refreshes and the call succeeds', async () => {
+    tokenEndpointHits = 0;
+    const clients = createClients('EXPIRED_STALE_TOKEN', 'VALID_REFRESH_TOKEN');
+    (
+      clients.auth as unknown as { endpoints: { oauth2TokenUrl: string } }
+    ).endpoints.oauth2TokenUrl = `${base}/token`;
+
+    const res = await clients.auth.request<{ ok: boolean }>({ url: `${base}/api`, method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ ok: true });
+    expect(tokenEndpointHits).toBe(1); // exactly one refresh happened, then the retry succeeded
+  });
+});

--- a/src/remoteWrapper.ts
+++ b/src/remoteWrapper.ts
@@ -34,7 +34,7 @@ function checkDomain(idToken?: string): boolean {
   }
 }
 
-function createClients(accessToken: string, refreshToken?: string): RequestClients {
+export function createClients(accessToken: string, refreshToken?: string): RequestClients {
   const auth = new OAuth2Client(process.env.GOOGLE_CLIENT_ID, process.env.GOOGLE_CLIENT_SECRET);
   auth.setCredentials({
     access_token: accessToken,

--- a/src/upstreamAuth.test.ts
+++ b/src/upstreamAuth.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { OAuthProxy } from 'fastmcp/auth';
+import { withOfflineAccess, enableUpstreamOfflineAccess } from './upstreamAuth.js';
+
+const GOOGLE_AUTH_URL =
+  'https://accounts.google.com/o/oauth2/v2/auth' +
+  '?client_id=test-client-id' +
+  '&redirect_uri=https%3A%2F%2Fexample.com%2Foauth%2Fcallback' +
+  '&response_type=code' +
+  '&state=txn-1' +
+  '&scope=openid+email' +
+  '&code_challenge=abc123' +
+  '&code_challenge_method=S256';
+
+function redirect(location: string | null, status = 302): Response {
+  const headers = new Headers();
+  if (location !== null) headers.set('Location', location);
+  return new Response(null, { status, headers });
+}
+
+describe('withOfflineAccess', () => {
+  it('adds access_type=offline and prompt=consent to the Location URL', () => {
+    const out = withOfflineAccess(redirect(GOOGLE_AUTH_URL));
+    const url = new URL(out.headers.get('Location')!);
+    expect(url.searchParams.get('access_type')).toBe('offline');
+    expect(url.searchParams.get('prompt')).toBe('consent');
+  });
+
+  it('preserves all pre-existing authorization parameters', () => {
+    const out = withOfflineAccess(redirect(GOOGLE_AUTH_URL));
+    const url = new URL(out.headers.get('Location')!);
+    expect(url.searchParams.get('client_id')).toBe('test-client-id');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://example.com/oauth/callback');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('state')).toBe('txn-1');
+    expect(url.searchParams.get('scope')).toBe('openid email');
+    expect(url.searchParams.get('code_challenge')).toBe('abc123');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.origin + url.pathname).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+  });
+
+  it('preserves the redirect status code', () => {
+    expect(withOfflineAccess(redirect(GOOGLE_AUTH_URL, 302)).status).toBe(302);
+    expect(withOfflineAccess(redirect(GOOGLE_AUTH_URL, 307)).status).toBe(307);
+  });
+
+  it('overwrites a pre-existing prompt/access_type rather than duplicating it', () => {
+    const out = withOfflineAccess(redirect(`${GOOGLE_AUTH_URL}&access_type=online&prompt=none`));
+    const url = new URL(out.headers.get('Location')!);
+    expect(url.searchParams.getAll('access_type')).toEqual(['offline']);
+    expect(url.searchParams.getAll('prompt')).toEqual(['consent']);
+  });
+
+  it('returns the response unchanged when there is no Location header', () => {
+    const res = redirect(null);
+    expect(withOfflineAccess(res)).toBe(res);
+  });
+
+  it('returns the response unchanged when the Location is not an absolute URL', () => {
+    const res = redirect('/relative/path');
+    expect(withOfflineAccess(res)).toBe(res);
+  });
+});
+
+describe('enableUpstreamOfflineAccess', () => {
+  it('wraps redirectToUpstream so its output requests offline access', () => {
+    const proxy = {
+      redirectToUpstream(_transaction: unknown): Response {
+        return redirect(GOOGLE_AUTH_URL);
+      },
+    };
+
+    enableUpstreamOfflineAccess(proxy as unknown as OAuthProxy);
+
+    const out = proxy.redirectToUpstream({ id: 'txn-1' });
+    const url = new URL(out.headers.get('Location')!);
+    expect(url.searchParams.get('access_type')).toBe('offline');
+    expect(url.searchParams.get('prompt')).toBe('consent');
+    // original params still present
+    expect(url.searchParams.get('client_id')).toBe('test-client-id');
+  });
+
+  it('patches a real OAuthProxy instance end-to-end', () => {
+    const proxy = new OAuthProxy({
+      upstreamAuthorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+      upstreamTokenEndpoint: 'https://oauth2.googleapis.com/token',
+      upstreamClientId: 'test-client-id',
+      upstreamClientSecret: 'test-secret',
+      baseUrl: 'https://example.com',
+      scopes: ['openid', 'email'],
+      allowedRedirectUriPatterns: ['https://example.com/*'],
+      jwtSigningKey: '0'.repeat(64),
+      encryptionKey: '0'.repeat(64),
+      consentRequired: false,
+    });
+
+    enableUpstreamOfflineAccess(proxy);
+
+    const response = (
+      proxy as unknown as { redirectToUpstream: (t: unknown) => Response }
+    ).redirectToUpstream({
+      id: 'txn-1',
+      scope: ['openid', 'email'],
+      proxyCodeChallenge: 'challenge',
+    });
+
+    const url = new URL(response.headers.get('Location')!);
+    expect(url.origin + url.pathname).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+    expect(url.searchParams.get('access_type')).toBe('offline');
+    expect(url.searchParams.get('prompt')).toBe('consent');
+    // FastMCP-built params survive the rewrite
+    expect(url.searchParams.get('client_id')).toBe('test-client-id');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('state')).toBe('txn-1');
+  });
+});

--- a/src/upstreamAuth.ts
+++ b/src/upstreamAuth.ts
@@ -1,0 +1,70 @@
+// src/upstreamAuth.ts
+//
+// Forces Google "offline access" on the upstream OAuth authorization redirect
+// so that the upstream token exchange returns a refresh_token.
+//
+// Why this exists:
+//   Google only issues a refresh_token when the authorization request includes
+//   `access_type=offline`. FastMCP v4's OAuthProxy.redirectToUpstream() builds
+//   the Google consent URL with client_id, redirect_uri, response_type, state,
+//   scope and PKCE — but never `access_type=offline`, and exposes no hook for
+//   extra authorization parameters. Without a refresh_token the stored Google
+//   access token (1-hour lifetime) can never be renewed: ~1 hour after a user
+//   authenticates, every Google API call fails with "invalid authentication
+//   credentials" until they manually re-authenticate.
+//
+//   With a refresh_token present, no further change is needed downstream:
+//   remoteWrapper.createClients() already sets the refresh_token on the
+//   per-request OAuth2Client and omits expiry_date, which is exactly the
+//   condition under which google-auth-library auto-refreshes on a 401/403 and
+//   retries the request (see oauth2client.requestAsync `mayRequireRefresh`).
+//
+//   `prompt=consent` is required so Google re-issues a refresh_token to users
+//   who previously authorized the app WITHOUT offline access (i.e. everyone
+//   who connected before this fix); otherwise Google suppresses the
+//   refresh_token on subsequent grants.
+
+import type { OAuthProxy } from 'fastmcp/auth';
+
+/**
+ * Rewrite a 302 authorization redirect Response so its Location requests Google
+ * offline access. Returns the response unchanged if it has no Location header or
+ * a non-absolute/invalid Location URL. All other headers and the status are
+ * preserved; only the Location query string is augmented.
+ */
+export function withOfflineAccess(response: Response): Response {
+  const location = response.headers.get('Location');
+  if (!location) return response;
+
+  let url: URL;
+  try {
+    url = new URL(location);
+  } catch {
+    return response;
+  }
+
+  url.searchParams.set('access_type', 'offline');
+  url.searchParams.set('prompt', 'consent');
+
+  const headers = new Headers(response.headers);
+  headers.set('Location', url.toString());
+
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
+ * Patch an OAuthProxy instance so every upstream authorization redirect requests
+ * Google offline access. Relies on OAuthProxy.redirectToUpstream being
+ * synchronous (true in fastmcp 4.0.1, which the fork pins).
+ */
+export function enableUpstreamOfflineAccess(oauthProxy: OAuthProxy): void {
+  const proxy = oauthProxy as unknown as {
+    redirectToUpstream: (transaction: unknown) => Response;
+  };
+  const original = proxy.redirectToUpstream.bind(proxy);
+  proxy.redirectToUpstream = (transaction: unknown) => withOfflineAccess(original(transaction));
+}


### PR DESCRIPTION
## Summary

- **Sync fork with upstream/main** — pulls in stateless env var (MCP_STATELESS), sheets comment features, and config.ts extraction
- **Fix: Google access tokens expire after 1 hour and are never refreshed** — the remote OAuthProxy never sent `access_type=offline` to Google, so Google issued no refresh_token. Every Google API call failed ~1 hour after a user authenticated. Patches `OAuthProxy.redirectToUpstream` to add `access_type=offline` + `prompt=consent`
- **Reproduction test** — proves the bug on unpatched production code (real OAuthProxy lacks offline access, real `createClients` fails without refresh token, succeeds with one)
- **Version bump** 1.11.0 → 1.11.1

## How it works

With the fix, `google-auth-library`'s `OAuth2Client` auto-refreshes on 401 via the stored refresh token — no other code change needed. Users must reconnect once to obtain a refresh token; after that, connections self-heal indefinitely.

## Verified in production

- Natural token expiry (1h+): self-healed ✓
- Force-expired access token: self-healed ✓
- Cold start from scale-to-zero + expired token: self-healed ✓
- 277 tests pass, Prettier clean

## Test plan

- [x] Reproduce bug on synced base without fix (RED)
- [x] Cherry-pick fix, verify tests pass (GREEN)
- [x] Deploy to prod, re-auth, wait 1+ hour past token expiry
- [x] Confirm tool call succeeds without re-auth (natural expiry)
- [x] Force-invalidate access token, confirm silent refresh
- [x] Isolated test service with min-instances=0: scale-to-zero → cold start → expired token → self-healed

🤖 Generated with [Claude Code](https://claude.com/claude-code)