### PR TITLE
test: fix stale fields assertion in findTextRange test

### DIFF
--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -45,7 +45,7 @@ describe('Text Range Finding', () => {
         mockDocs.documents.get.mock.calls[0].arguments[0], 
         {
           documentId: 'doc123',
-          fields: 'body(content(paragraph(elements(startIndex,endIndex,textRun(content)))))'
+          fields: 'body(content(paragraph(elements(startIndex,endIndex,textRun(content))),table,sectionBreak,tableOfContents,startIndex,endIndex))'
         }
       );
     });


### PR DESCRIPTION
## What

`tests/helpers.test.js` asserted that `findTextRange` calls `documents.get` with a minimal fields mask:

```
body(content(paragraph(elements(startIndex,endIndex,textRun(content)))))
```

But the implementation requests a richer mask to handle non-paragraph containers (tables, section breaks, structural indices):

```
body(content(paragraph(elements(startIndex,endIndex,textRun(content))),table,sectionBreak,tableOfContents,startIndex,endIndex))
```

The assertion was stale, so the test failed on `main`. This updates the expected string to match the implementation. No production code changes; `node --test tests/helpers.test.js tests/types.test.js` now passes 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)