### PR TITLE
fix: declare xsschema as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a-bonus/google-docs-mcp",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a-bonus/google-docs-mcp",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/firestore": "^8.3.0",
@@ -14,6 +14,7 @@
         "google-auth-library": "^10.5.0",
         "googleapis": "^171.4.0",
         "markdown-it": "^14.1.0",
+        "xsschema": "^0.4.4",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -2147,7 +2148,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2795,7 +2795,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
       "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3601,7 +3600,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4451,7 +4449,6 @@
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -4581,7 +4578,6 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "google-auth-library": "^10.5.0",
     "googleapis": "^171.4.0",
     "markdown-it": "^14.1.0",
+    "xsschema": "^0.4.4",
     "zod": "^3.24.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Thanks for this MCP — it has been useful connecting Cursor to Google Workspace.

## Summary
- `src/cachedToolsList.ts` imports `toJsonSchema` from `xsschema`, but `xsschema` was not listed in `package.json` dependencies
- With `npx -y @a-bonus/google-docs-mcp`, Node resolves from the published package root and fails with `ERR_MODULE_NOT_FOUND: Cannot find package 'xsschema'`
- Declare `xsschema` as a direct dependency so published/npx installs work

## Test plan
- [ ] Fresh install: `npx -y @a-bonus/google-docs-mcp@<version-with-fix> auth` starts without `xsschema` module errors
- [ ] `npm pack` / local `npm start` still boots tool registration normally