### PR TITLE
Make re-authorization actually re-authorize

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -223,8 +223,15 @@ async function authenticate(): Promise<OAuth2Client> {
 
   const state = crypto.randomBytes(32).toString('hex');
 
+  // prompt: 'consent' is what makes re-authorization actually work. Google returns a refresh
+  // token only when it re-asks for consent; for an app the user already granted, an offline
+  // request without it yields an access token and no refresh token. Since only the refresh
+  // token is persisted, a re-auth would then save nothing and leave the old grant — and its
+  // old, narrower scope set — in place, while still reporting success. Adding a scope to
+  // SCOPES would appear to do nothing at all.
   const authorizeUrl = oAuth2Client.generateAuthUrl({
     access_type: 'offline',
+    prompt: 'consent',
     scope: SCOPES.join(' '),
     state,
   });
@@ -271,12 +278,18 @@ async function authenticate(): Promise<OAuth2Client> {
 
   const { tokens } = await oAuth2Client.getToken(code);
   oAuth2Client.setCredentials(tokens);
-  if (tokens.refresh_token) {
-    await saveCredentials(oAuth2Client);
-  } else {
-    logger.warn('Did not receive refresh token. Token might expire.');
+  if (!tokens.refresh_token) {
+    // Nothing is persisted without a refresh token, so this run changed nothing on disk. Said
+    // as a warning it reads as a minor caveat under a success message, and the stale grant
+    // goes unnoticed until some tool fails for a reason that looks unrelated.
+    throw new Error(
+      'Google returned no refresh token, so nothing was saved and the previous authorization ' +
+        '(with whatever scopes it had) is still in force. Revoke this app at ' +
+        'https://myaccount.google.com/permissions and run the auth flow again.'
+    );
   }
-  logger.info('Authentication successful!');
+  await saveCredentials(oAuth2Client);
+  logger.info(`Authentication successful! Granted scopes: ${tokens.scope ?? '(not reported)'}`);
   return oAuth2Client;
 }
 


### PR DESCRIPTION
## The bug

`generateAuthUrl` asks for `access_type: 'offline'` but never for `prompt: 'consent'`.

For an app the user has already granted, Google answers that with an access token and **no refresh token**. Since `saveCredentials` only runs `if (tokens.refresh_token)`, the flow writes nothing to disk — and then logs `Authentication successful!`.

The `auth` subcommand exists so that a user can re-authorize. It cannot.

## Why it matters more than it looks

The failure is silent and cumulative: **any scope added to `SCOPES` never takes effect.**

A user who adds `spreadsheets`, `gmail.modify` or `calendar.events` re-authorizes, sees success, and keeps whatever token they already had. The corresponding tools then answer 403 — with a message about access rights that sends the reader looking at file sharing rather than at the OAuth grant.

I hit this on a server whose `SCOPES` listed six entries while the stored token carried two. `listSpreadsheets` worked (it goes through the Drive API, and `drive` was granted); `readSpreadsheet` returned "Permission denied … Ensure you have read access" for a spreadsheet the user owned. Every Sheets, Gmail and Calendar tool had been dead for an unknown length of time, and re-authorizing appeared to succeed each time.

Confirmed by reading back what the token actually carried, via `oauth2/v3/tokeninfo`, rather than trusting what the code requested.

## The change

- `prompt: 'consent'` on the authorization URL, which forces the screen and with it a fresh refresh token.
- A run that receives no refresh token now **throws** instead of warning. Nothing was persisted, the previous grant is still in force, and saying that quietly beneath a success message is exactly what let the problem go unnoticed.
- The granted scopes are logged on success, so the outcome of an authorization is visible rather than assumed.

## Scope

`src/auth.ts` only. No behaviour change for a first-time authorization, which already received a refresh token; the difference is that repeat authorizations now do what they claim. `npm test` passes.
