### PR TITLE
Fix orphaned server processes spinning at 100% CPU after client disconnect

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -67,15 +67,30 @@ throw new Error("Google Docs, Drive, and Sheets clients could not be initialized
 return { authClient, googleDocs, googleDrive, googleSheets };
 }
 
+// Exit when the MCP client (Claude session) goes away, instead of lingering as an orphan
+process.stdin.on('end', () => process.exit(0));
+process.stdin.on('close', () => process.exit(0));
+
 // Set up process-level unhandled error/rejection handlers to prevent crashes
-process.on('uncaughtException', (error) => {
-  console.error('Uncaught Exception:', error);
+process.on('uncaughtException', (error: any) => {
+  // EPIPE means our client is gone; logging would throw again and spin the CPU
+  if (error?.code === 'EPIPE') process.exit(0);
+  try {
+    console.error('Uncaught Exception:', error);
+  } catch {
+    process.exit(0);
+  }
   // Don't exit process, just log the error and continue
   // This will catch timeout errors that might otherwise crash the server
 });
 
-process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled Promise Rejection:', reason);
+process.on('unhandledRejection', (reason: any, promise) => {
+  if (reason?.code === 'EPIPE') process.exit(0);
+  try {
+    console.error('Unhandled Promise Rejection:', reason);
+  } catch {
+    process.exit(0);
+  }
   // Don't exit process, just log the error and continue
 });
 


### PR DESCRIPTION
## Problem

When the MCP client that spawned the server exits (e.g. closing a Claude Code / Claude Desktop session), the server process does not notice and keeps running as an orphan. Worse: once the parent is gone, stderr is a broken pipe, so `console.error` inside the `uncaughtException` handler throws `EPIPE` — which is caught by that same handler, which logs again, throwing again. The result is an infinite tight exception loop that pins a full CPU core indefinitely.

Because a new server instance is spawned per client session, these orphans accumulate. On my machine I found 8 of them, the oldest running for 22 days, together burning ~8 cores continuously — a substantial battery/thermal drain that is easy to miss since each one is invisible unless you check `ps`.

Reproduce: start the server from any MCP client over stdio, kill the client, then watch the leftover `node dist/server.js` process (parent PID 1) sit at ~100% CPU.

## Fix

- Exit cleanly when stdin ends/closes (the standard signal that the stdio MCP client is gone).
- In the `uncaughtException` / `unhandledRejection` handlers, exit on `EPIPE` instead of re-logging, and wrap the remaining logging in try/catch so a dead stderr can never loop.

Verified: with this patch, `node dist/server.js < /dev/null` exits immediately instead of lingering at 100% CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)