### PR TITLE
feat(script): add Apps Script project tools (create / read / update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ Tools across Google Docs, Sheets, and Drive:
 | `deleteEvent`   | Permanently delete an event. Optional `sendUpdates` emails cancellations to attendees              |
 | `quickAddEvent` | Natural-language event creation: `"Lunch with Sarah tomorrow 12pm"` — Google parses the rest       |
 
+### Apps Script
+
+Automate the automation: create and edit the Apps Script behind a Doc or Sheet — `onEdit` triggers, custom menus, scheduled jobs — instead of telling the user to paste code into the editor by hand.
+
+| Tool                      | Description                                                                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `createAppsScriptProject` | Create a project, optionally **bound** to a Doc/Sheet/Slides/Form via `parentId`, and write its initial files in the same call      |
+| `getAppsScriptContent`    | Read a project's files — pass `includeSource: false` for a quick listing, or `versionNumber` to read a saved version                |
+| `updateAppsScriptContent` | Write files. `merge` (default) replaces same-named files and keeps the rest; `replace` makes the project exactly the files you pass |
+
+**Requires two things beyond the usual setup:**
+
+1. The Apps Script API must be enabled **per Google account** at <https://script.google.com/home/usersettings> — it is off by default, and a 403 with "Apps Script API" in the message means this step was missed.
+2. The `script.projects` scope, which is included in `SCOPES`. Existing installs must re-authorize once to pick it up.
+
 ---
 
 ## Usage Examples
@@ -322,20 +337,20 @@ Visit the server root URL (`/`) for setup instructions and a ready-to-copy clien
 
 ### Environment Variables
 
-| Variable               | Description                                                                                                         |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `MCP_TRANSPORT`        | Set to `httpStream` to enable remote mode (default: `stdio`)                                                        |
-| `BASE_URL`             | Public URL of the deployed server (required for OAuth redirects)                                                    |
-| `GOOGLE_CLIENT_ID`     | OAuth client ID (Web application type)                                                                              |
-| `GOOGLE_CLIENT_SECRET` | OAuth client secret                                                                                                 |
-| `MCP_TOOL_GROUPS`      | Optional comma-separated tool groups to register: `docs`, `drive`, `sheets`, `utils`, `gmail`, `calendar`, or `all` |
-| `ALLOWED_DOMAINS`      | Comma-separated list of allowed Google Workspace domains (optional)                                                 |
-| `PORT`                 | HTTP port (default: `8080`)                                                                                         |
-| `TOKEN_STORE`          | Set to `firestore` for persistent token storage (default: in-memory)                                                |
-| `JWT_SIGNING_KEY`      | Fixed signing key so tokens survive restarts (auto-generated if not set)                                            |
-| `REFRESH_TOKEN_TTL`    | Refresh token lifetime in seconds (default: `2592000` / 30 days)                                                    |
-| `GCLOUD_PROJECT`       | GCP project ID for Firestore (required when `TOKEN_STORE=firestore`)                                                |
-| `MCP_STATELESS`        | Set to `true` for serverless deployments (Cloud Run, etc.) — disables session tracking to survive scale-to-zero     |
+| Variable               | Description                                                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `MCP_TRANSPORT`        | Set to `httpStream` to enable remote mode (default: `stdio`)                                                                  |
+| `BASE_URL`             | Public URL of the deployed server (required for OAuth redirects)                                                              |
+| `GOOGLE_CLIENT_ID`     | OAuth client ID (Web application type)                                                                                        |
+| `GOOGLE_CLIENT_SECRET` | OAuth client secret                                                                                                           |
+| `MCP_TOOL_GROUPS`      | Optional comma-separated tool groups to register: `docs`, `drive`, `sheets`, `utils`, `gmail`, `calendar`, `script`, or `all` |
+| `ALLOWED_DOMAINS`      | Comma-separated list of allowed Google Workspace domains (optional)                                                           |
+| `PORT`                 | HTTP port (default: `8080`)                                                                                                   |
+| `TOKEN_STORE`          | Set to `firestore` for persistent token storage (default: in-memory)                                                          |
+| `JWT_SIGNING_KEY`      | Fixed signing key so tokens survive restarts (auto-generated if not set)                                                      |
+| `REFRESH_TOKEN_TTL`    | Refresh token lifetime in seconds (default: `2592000` / 30 days)                                                              |
+| `GCLOUD_PROJECT`       | GCP project ID for Firestore (required when `TOKEN_STORE=firestore`)                                                          |
+| `MCP_STATELESS`        | Set to `true` for serverless deployments (Cloud Run, etc.) — disables session tracking to survive scale-to-zero               |
 
 ### Setup
 
@@ -480,6 +495,8 @@ Without `GOOGLE_MCP_PROFILE`, behavior is unchanged.
 - **Gmail attachments:** `getMessage` returns attachment metadata but does not download attachment bytes yet.
 - **Gmail HTML email send:** `sendEmail` sends plain-text only. For HTML bodies, paste HTML into the `body` field — it will be delivered as text, not rendered.
 - **Calendar scope:** `calendar.events` permits event CRUD on existing calendars but cannot create or delete entire calendars themselves.
+- **Apps Script API is off by default:** every account must enable it once at <https://script.google.com/home/usersettings>. The tools cannot turn it on for you.
+- **Apps Script deployments:** the tools edit project source. Creating versions, deployments and installable triggers is not exposed yet — simple triggers such as `onEdit` and `onOpen` work without any of that.
 - **Calendar recurring events:** `updateEvent` and `deleteEvent` modify the entire recurring series unless you target a specific instance ID returned by `listEvents` with `singleEvents=true`.
 
 ## Troubleshooting

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -54,6 +54,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/drive',
   'https://www.googleapis.com/auth/spreadsheets',
   'https://www.googleapis.com/auth/script.external_request',
+  'https://www.googleapis.com/auth/script.projects',
   'https://www.googleapis.com/auth/gmail.modify',
   'https://www.googleapis.com/auth/calendar.events',
 ];

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,8 +6,17 @@ import { registerSheetsTools } from './sheets/index.js';
 import { registerUtilsTools } from './utils/index.js';
 import { registerGmailTools } from './gmail/index.js';
 import { registerCalendarTools } from './calendar/index.js';
+import { registerScriptTools } from './script/index.js';
 
-export const TOOL_GROUPS = ['docs', 'drive', 'sheets', 'utils', 'gmail', 'calendar'] as const;
+export const TOOL_GROUPS = [
+  'docs',
+  'drive',
+  'sheets',
+  'utils',
+  'gmail',
+  'calendar',
+  'script',
+] as const;
 
 export type ToolGroup = (typeof TOOL_GROUPS)[number];
 
@@ -62,6 +71,9 @@ export function registerAllTools(
         break;
       case 'calendar':
         registerCalendarTools(server);
+        break;
+      case 'script':
+        registerScriptTools(server);
         break;
     }
   }

--- a/src/tools/script/appsScriptShared.test.ts
+++ b/src/tools/script/appsScriptShared.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MANIFEST_SOURCE,
+  MANIFEST_FILE_NAME,
+  ensureManifest,
+  inferFileType,
+  mergeFiles,
+  toApiFiles,
+} from './appsScriptShared.js';
+
+describe('inferFileType', () => {
+  it('treats the manifest as JSON', () => {
+    expect(inferFileType('appsscript')).toBe('JSON');
+    expect(inferFileType('appsscript.json')).toBe('JSON');
+  });
+
+  it('treats .html as HTML', () => {
+    expect(inferFileType('sidebar.html')).toBe('HTML');
+    expect(inferFileType('Sidebar.HTML')).toBe('HTML');
+  });
+
+  it('defaults everything else to SERVER_JS', () => {
+    expect(inferFileType('Code')).toBe('SERVER_JS');
+    expect(inferFileType('Code.gs')).toBe('SERVER_JS');
+    expect(inferFileType('utils.js')).toBe('SERVER_JS');
+  });
+});
+
+describe('toApiFiles', () => {
+  it('strips known extensions from the file name', () => {
+    const files = toApiFiles([{ name: 'Code.gs', source: 'function a() {}' }]);
+    expect(files).toEqual([{ name: 'Code', type: 'SERVER_JS', source: 'function a() {}' }]);
+  });
+
+  it('keeps an explicit type over the inferred one', () => {
+    const files = toApiFiles([{ name: 'Page', type: 'HTML', source: '<div></div>' }]);
+    expect(files[0].type).toBe('HTML');
+  });
+
+  it('does not strip a dot that is not a known extension', () => {
+    const files = toApiFiles([{ name: 'my.helper', source: '' }]);
+    expect(files[0].name).toBe('my.helper');
+  });
+});
+
+describe('mergeFiles', () => {
+  const existing = [
+    { name: 'appsscript', type: 'JSON', source: '{}' },
+    { name: 'Code', type: 'SERVER_JS', source: 'old' },
+    { name: 'Utils', type: 'SERVER_JS', source: 'keep me' },
+  ];
+
+  it('replaces files with the same name', () => {
+    const merged = mergeFiles(existing, [{ name: 'Code', type: 'SERVER_JS', source: 'new' }]);
+    expect(merged.find((f) => f.name === 'Code')?.source).toBe('new');
+  });
+
+  it('keeps files that are not part of the update', () => {
+    const merged = mergeFiles(existing, [{ name: 'Code', type: 'SERVER_JS', source: 'new' }]);
+    expect(merged.find((f) => f.name === 'Utils')?.source).toBe('keep me');
+    expect(merged).toHaveLength(3);
+  });
+
+  it('appends files that did not exist yet', () => {
+    const merged = mergeFiles(existing, [{ name: 'New', type: 'SERVER_JS', source: 'x' }]);
+    expect(merged).toHaveLength(4);
+  });
+});
+
+describe('ensureManifest', () => {
+  it('leaves the payload untouched when it already carries a manifest', () => {
+    const files = [{ name: MANIFEST_FILE_NAME, type: 'JSON', source: '{"runtimeVersion":"V8"}' }];
+    expect(ensureManifest(files, [])).toEqual(files);
+  });
+
+  it('reuses the manifest already in the project', () => {
+    const existing = [
+      { name: MANIFEST_FILE_NAME, type: 'JSON', source: '{"timeZone":"Asia/Tokyo"}' },
+    ];
+    const result = ensureManifest([{ name: 'Code', type: 'SERVER_JS', source: '' }], existing);
+    expect(result[0]).toEqual(existing[0]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('falls back to a default manifest when the project has none', () => {
+    const result = ensureManifest([{ name: 'Code', type: 'SERVER_JS', source: '' }], []);
+    expect(result[0].name).toBe(MANIFEST_FILE_NAME);
+    expect(result[0].source).toBe(DEFAULT_MANIFEST_SOURCE);
+  });
+
+  it('produces a manifest that is valid JSON', () => {
+    expect(() => JSON.parse(DEFAULT_MANIFEST_SOURCE)).not.toThrow();
+  });
+});

--- a/src/tools/script/appsScriptShared.ts
+++ b/src/tools/script/appsScriptShared.ts
@@ -1,0 +1,129 @@
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import type { script_v1 } from 'googleapis';
+
+/** File types supported by an Apps Script project. */
+export const AppsScriptFileTypeSchema = z.enum(['SERVER_JS', 'HTML', 'JSON']);
+
+export const AppsScriptFileSchema = z.strictObject({
+  name: z
+    .string()
+    .min(1)
+    .describe(
+      'File name without extension, e.g. "Code" or "appsscript". The manifest file must be named "appsscript".'
+    ),
+  type: AppsScriptFileTypeSchema.optional().describe(
+    'File type. Inferred from the name when omitted: "appsscript" becomes JSON, names ending in .html become HTML, everything else becomes SERVER_JS.'
+  ),
+  source: z.string().describe('Full file content.'),
+});
+
+export type AppsScriptFileInput = z.infer<typeof AppsScriptFileSchema>;
+
+export const MANIFEST_FILE_NAME = 'appsscript';
+
+/** Minimal manifest used when a project has none and the caller did not supply one. */
+export const DEFAULT_MANIFEST_SOURCE = JSON.stringify(
+  {
+    timeZone: 'Etc/GMT',
+    dependencies: {},
+    exceptionLogging: 'STACKDRIVER',
+    runtimeVersion: 'V8',
+  },
+  null,
+  2
+);
+
+/** Strips a trailing extension so callers may pass either "Code" or "Code.gs". */
+function stripExtension(name: string): string {
+  return name.replace(/\.(gs|js|html|json)$/i, '');
+}
+
+/** Derives the Apps Script file type from a file name when the caller omitted it. */
+export function inferFileType(name: string): z.infer<typeof AppsScriptFileTypeSchema> {
+  const lower = name.toLowerCase();
+  if (stripExtension(lower) === MANIFEST_FILE_NAME) return 'JSON';
+  if (lower.endsWith('.html')) return 'HTML';
+  return 'SERVER_JS';
+}
+
+/** Normalises caller input into the shape the Apps Script API expects. */
+export function toApiFiles(files: AppsScriptFileInput[]): script_v1.Schema$File[] {
+  return files.map((file) => ({
+    name: stripExtension(file.name),
+    type: file.type ?? inferFileType(file.name),
+    source: file.source,
+  }));
+}
+
+/**
+ * Merges incoming files over the files already in the project.
+ * Files with the same name are replaced; every other existing file is kept.
+ */
+export function mergeFiles(
+  existing: script_v1.Schema$File[],
+  incoming: script_v1.Schema$File[]
+): script_v1.Schema$File[] {
+  const byName = new Map<string, script_v1.Schema$File>();
+  for (const file of existing) {
+    if (file.name) byName.set(file.name, file);
+  }
+  for (const file of incoming) {
+    if (file.name) byName.set(file.name, file);
+  }
+  return [...byName.values()];
+}
+
+/**
+ * The API rejects an update whose payload has no manifest, so fall back to the
+ * project's current manifest and finally to a minimal default.
+ */
+export function ensureManifest(
+  files: script_v1.Schema$File[],
+  existing: script_v1.Schema$File[]
+): script_v1.Schema$File[] {
+  if (files.some((file) => file.name === MANIFEST_FILE_NAME)) return files;
+
+  const currentManifest = existing.find((file) => file.name === MANIFEST_FILE_NAME);
+  return [
+    currentManifest ?? {
+      name: MANIFEST_FILE_NAME,
+      type: 'JSON',
+      source: DEFAULT_MANIFEST_SOURCE,
+    },
+    ...files,
+  ];
+}
+
+/** Turns raw Google API failures into messages that say what to do next. */
+export function toUserError(error: any, action: string): UserError {
+  const message: string = error?.message ?? String(error);
+  const status = error?.code ?? error?.response?.status;
+
+  if (status === 403 && /Apps Script API/i.test(message)) {
+    return new UserError(
+      'The Apps Script API is turned off for this Google account. Enable it at https://script.google.com/home/usersettings and try again.'
+    );
+  }
+  if (status === 403) {
+    return new UserError(
+      `Permission denied while ${action}. The account needs edit access to the project, and the OAuth token needs the script.projects scope - re-authorize if the token predates that scope.`
+    );
+  }
+  if (status === 404) {
+    return new UserError(
+      `Not found while ${action}. Check the script ID - it is the long ID in the /projects/<scriptId>/ part of the Apps Script editor URL, not the spreadsheet ID.`
+    );
+  }
+  if (status === 400 && /parent/i.test(message)) {
+    return new UserError(
+      'Invalid parentId. It must be the file ID of an existing Doc, Sheet, Slides or Form that the account can edit.'
+    );
+  }
+  return new UserError(`Failed while ${action}: ${message || 'Unknown error'}`);
+}
+
+/** Editor URL for a script project. */
+export function scriptUrl(scriptId: string): string {
+  return `https://script.google.com/d/${scriptId}/edit`;
+}

--- a/src/tools/script/createAppsScriptProject.ts
+++ b/src/tools/script/createAppsScriptProject.ts
@@ -1,0 +1,99 @@
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getScriptClient } from '../../clients.js';
+import {
+  AppsScriptFileSchema,
+  ensureManifest,
+  scriptUrl,
+  toApiFiles,
+  toUserError,
+} from './appsScriptShared.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'createAppsScriptProject',
+    description:
+      'Creates an Apps Script project, optionally bound to a Doc, Sheet, Slides or Form so its triggers and custom menus run inside that file. Optionally writes the initial files in the same call. Requires the Apps Script API to be enabled at https://script.google.com/home/usersettings.',
+    parameters: z.strictObject({
+      title: z.string().min(1).describe('Title of the new script project.'),
+      parentId: z
+        .string()
+        .optional()
+        .describe(
+          'File ID of the Doc, Sheet, Slides or Form to bind the project to (a container-bound script). Omit to create a standalone project in Drive.'
+        ),
+      files: z
+        .array(AppsScriptFileSchema)
+        .optional()
+        .describe(
+          'Initial files to write after the project is created. A manifest is added automatically when the list has none.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const script = await getScriptClient();
+      log.info(
+        `Creating Apps Script project "${args.title}"${args.parentId ? ` bound to ${args.parentId}` : ' (standalone)'}`
+      );
+
+      let scriptId: string;
+      try {
+        const created = await script.projects.create({
+          requestBody: {
+            title: args.title,
+            ...(args.parentId ? { parentId: args.parentId } : {}),
+          },
+        });
+
+        if (!created.data.scriptId) {
+          throw new UserError('Project was created but the API returned no scriptId.');
+        }
+        scriptId = created.data.scriptId;
+      } catch (error: any) {
+        if (error instanceof UserError) throw error;
+        log.error(`Error creating Apps Script project: ${error.message || error}`);
+        throw toUserError(error, 'creating the Apps Script project');
+      }
+
+      let filesWritten: number | undefined;
+      if (args.files && args.files.length > 0) {
+        try {
+          // A freshly created project already carries a default manifest; keep it
+          // unless the caller supplied one of their own.
+          const current = await script.projects.getContent({ scriptId });
+          const existing = current.data.files ?? [];
+          const payload = ensureManifest(toApiFiles(args.files), existing);
+
+          await script.projects.updateContent({
+            scriptId,
+            requestBody: { files: payload },
+          });
+          filesWritten = payload.length;
+        } catch (error: any) {
+          log.warn(`Project created but writing files failed: ${error.message || error}`);
+          return JSON.stringify(
+            {
+              scriptId,
+              url: scriptUrl(scriptId),
+              filesWritten: 0,
+              warning: `Project created, but writing the initial files failed: ${error.message || error}. Retry with updateAppsScriptContent.`,
+            },
+            null,
+            2
+          );
+        }
+      }
+
+      return JSON.stringify(
+        {
+          scriptId,
+          url: scriptUrl(scriptId),
+          bound: Boolean(args.parentId),
+          ...(filesWritten !== undefined ? { filesWritten } : {}),
+        },
+        null,
+        2
+      );
+    },
+  });
+}

--- a/src/tools/script/getAppsScriptContent.ts
+++ b/src/tools/script/getAppsScriptContent.ts
@@ -1,0 +1,67 @@
+import type { FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getScriptClient } from '../../clients.js';
+import { scriptUrl, toUserError } from './appsScriptShared.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'getAppsScriptContent',
+    description:
+      'Reads the files of an Apps Script project. Use it before updateAppsScriptContent to see what is already there, or to review code that is currently deployed.',
+    parameters: z.strictObject({
+      scriptId: z
+        .string()
+        .min(1)
+        .describe(
+          'Script project ID - the long ID in the /projects/<scriptId>/ part of the Apps Script editor URL. This is not the spreadsheet ID.'
+        ),
+      versionNumber: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Read a specific saved version instead of the current draft.'),
+      includeSource: z
+        .boolean()
+        .default(true)
+        .describe('Set to false to list file names and types without their content.'),
+    }),
+    execute: async (args, { log }) => {
+      const script = await getScriptClient();
+      log.info(`Reading Apps Script project ${args.scriptId}`);
+
+      try {
+        const response = await script.projects.getContent({
+          scriptId: args.scriptId,
+          ...(args.versionNumber ? { versionNumber: args.versionNumber } : {}),
+        });
+
+        const files = (response.data.files ?? []).map((file) => ({
+          name: file.name,
+          type: file.type,
+          ...(args.includeSource ? { source: file.source } : { lines: countLines(file.source) }),
+        }));
+
+        return JSON.stringify(
+          {
+            scriptId: args.scriptId,
+            url: scriptUrl(args.scriptId),
+            ...(args.versionNumber ? { versionNumber: args.versionNumber } : {}),
+            fileCount: files.length,
+            files,
+          },
+          null,
+          2
+        );
+      } catch (error: any) {
+        log.error(`Error reading Apps Script project: ${error.message || error}`);
+        throw toUserError(error, 'reading the Apps Script project');
+      }
+    },
+  });
+}
+
+function countLines(source: string | null | undefined): number {
+  if (!source) return 0;
+  return source.split('\n').length;
+}

--- a/src/tools/script/index.ts
+++ b/src/tools/script/index.ts
@@ -1,0 +1,16 @@
+import type { FastMCP } from 'fastmcp';
+import { register as createAppsScriptProject } from './createAppsScriptProject.js';
+import { register as getAppsScriptContent } from './getAppsScriptContent.js';
+import { register as updateAppsScriptContent } from './updateAppsScriptContent.js';
+
+/**
+ * Registers Apps Script project tools.
+ *
+ * These require the Apps Script API to be enabled per account at
+ * https://script.google.com/home/usersettings and the script.projects OAuth scope.
+ */
+export function registerScriptTools(server: FastMCP) {
+  createAppsScriptProject(server);
+  getAppsScriptContent(server);
+  updateAppsScriptContent(server);
+}

--- a/src/tools/script/updateAppsScriptContent.ts
+++ b/src/tools/script/updateAppsScriptContent.ts
@@ -1,0 +1,81 @@
+import type { FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getScriptClient } from '../../clients.js';
+import {
+  AppsScriptFileSchema,
+  ensureManifest,
+  mergeFiles,
+  scriptUrl,
+  toApiFiles,
+  toUserError,
+} from './appsScriptShared.js';
+
+export function register(server: FastMCP) {
+  server.addTool({
+    name: 'updateAppsScriptContent',
+    description:
+      'Writes files into an existing Apps Script project. Default mode "merge" replaces same-named files and keeps the rest; mode "replace" makes the project contain exactly the files passed in. The manifest is preserved automatically.',
+    parameters: z.strictObject({
+      scriptId: z
+        .string()
+        .min(1)
+        .describe(
+          'Script project ID - the long ID in the /projects/<scriptId>/ part of the Apps Script editor URL.'
+        ),
+      files: z
+        .array(AppsScriptFileSchema)
+        .min(1)
+        .describe('Files to write. Each one replaces the file of the same name.'),
+      mode: z
+        .enum(['merge', 'replace'])
+        .default('merge')
+        .describe(
+          'merge: keep files that are not in this call (default, safe). replace: delete every file not listed here.'
+        ),
+    }),
+    execute: async (args, { log }) => {
+      const script = await getScriptClient();
+      log.info(
+        `Updating Apps Script project ${args.scriptId} (${args.mode}, ${args.files.length} file(s))`
+      );
+
+      try {
+        const current = await script.projects.getContent({ scriptId: args.scriptId });
+        const existing = current.data.files ?? [];
+        const incoming = toApiFiles(args.files);
+
+        const combined = args.mode === 'merge' ? mergeFiles(existing, incoming) : incoming;
+        const payload = ensureManifest(combined, existing);
+
+        const response = await script.projects.updateContent({
+          scriptId: args.scriptId,
+          requestBody: { files: payload },
+        });
+
+        const written = response.data.files ?? payload;
+        const removed =
+          args.mode === 'replace'
+            ? existing
+                .map((file) => file.name)
+                .filter((name) => name && !payload.some((file) => file.name === name))
+            : [];
+
+        return JSON.stringify(
+          {
+            scriptId: args.scriptId,
+            url: scriptUrl(args.scriptId),
+            mode: args.mode,
+            filesInProject: written.length,
+            updated: incoming.map((file) => file.name),
+            ...(removed.length > 0 ? { removed } : {}),
+          },
+          null,
+          2
+        );
+      } catch (error: any) {
+        log.error(`Error updating Apps Script project: ${error.message || error}`);
+        throw toUserError(error, 'updating the Apps Script project');
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Why

The server already constructs a `script_v1` client in `clients.ts` and `insertImage` calls `scripts.run` on a deployed script — but there is no way to **create or edit a script project**. So anything that needs an `onEdit` trigger, a custom menu, or a scheduled job behind a Doc/Sheet ends with the assistant telling the user: *"now open Extensions → Apps Script and paste this by hand."*

That is the one automation gap left in an otherwise complete Docs/Sheets surface. This PR closes it.

## What

New `script` tool group:

| Tool | Description |
| --- | --- |
| `createAppsScriptProject` | Create a project, optionally **bound** to a Doc/Sheet/Slides/Form via `parentId`; can write initial files in the same call |
| `getAppsScriptContent` | Read project files; `includeSource: false` for a cheap listing, `versionNumber` to read a saved version |
| `updateAppsScriptContent` | Write files; `merge` (default) keeps files not named in the call, `replace` is opt-in |

## Design notes for review

**`updateContent` replaces the entire project.** A naive wrapper around it silently deletes every file the caller did not mention. Two guards:

- `mergeFiles` — default `merge` mode reads current content first and keeps untouched files
- `ensureManifest` — the API rejects a payload with no manifest, so the project's existing `appsscript` file is re-attached automatically (falling back to a minimal V8 manifest for a project that somehow has none)

**Ergonomics.** File names accept `Code` or `Code.gs`; type is inferred (`appsscript` → JSON, `*.html` → HTML, else SERVER_JS) unless passed explicitly.

**Error messages.** The Apps Script API is disabled per account by default. A 403 mentioning it is translated into a message pointing at <https://script.google.com/home/usersettings> instead of surfacing a raw Google error — this is the single most common failure for a first-time user.

## Breaking-ish change

Adds the `script.projects` OAuth scope. **Existing installs must re-authorize once** to pick it up; until then the new tools return a permission error that says exactly that. Documented in the README section and in the limitations list.

## Tests

- 13 new unit tests over the pure helpers: type inference, extension stripping, merge behaviour, manifest fallback, default manifest validity
- `src/tools/index.test.ts` still passes with the new group in `TOOL_GROUPS`
- Full suite: 289 passed / 1 skipped
- `npm run build` clean, `prettier --check` clean

## Not included

Versions, deployments and installable triggers are not exposed. Simple triggers (`onEdit`, `onOpen`) need none of that, so this keeps the PR reviewable; those can follow if there is interest.