### PR TITLE
Fix Drive fullText+orderBy 403 in list/search tools

### DIFF
--- a/src/tools/drive/listGoogleDocs.ts
+++ b/src/tools/drive/listGoogleDocs.ts
@@ -51,7 +51,9 @@ export function register(server: FastMCP) {
         const response = await drive.files.list({
           q: queryString,
           pageSize: args.maxResults,
-          orderBy: args.orderBy === 'name' ? 'name' : args.orderBy,
+          // Drive rejects `orderBy` when `q` contains a `fullText` clause
+          // ("Sorting is not supported for queries with fullText terms").
+          ...(args.query ? {} : { orderBy: args.orderBy === 'name' ? 'name' : args.orderBy }),
           fields:
             'files(id,name,modifiedTime,createdTime,size,webViewLink,owners(displayName,emailAddress))',
           supportsAllDrives: true,

--- a/src/tools/drive/searchDriveFiles.ts
+++ b/src/tools/drive/searchDriveFiles.ts
@@ -126,11 +126,15 @@ export function register(server: FastMCP) {
 
         const queryString = conditions.join(' and ');
         const orderByParam = args.sortDirection === 'desc' ? `${args.orderBy} desc` : args.orderBy;
+        // Drive rejects `orderBy` when `q` contains a `fullText` clause
+        // ("Sorting is not supported for queries with fullText terms") —
+        // only the "name" search mode avoids fullText.
+        const includesFullText = args.searchIn !== 'name';
 
         const response = await drive.files.list({
           q: queryString,
           pageSize: args.maxResults,
-          orderBy: orderByParam,
+          ...(includesFullText ? {} : { orderBy: orderByParam }),
           pageToken: args.pageToken,
           fields:
             'nextPageToken,files(id,name,mimeType,size,modifiedTime,createdTime,webViewLink,owners(displayName,emailAddress),parents)',

--- a/src/tools/drive/searchGoogleDocs.ts
+++ b/src/tools/drive/searchGoogleDocs.ts
@@ -55,7 +55,10 @@ export function register(server: FastMCP) {
         const response = await drive.files.list({
           q: queryString,
           pageSize: args.maxResults,
-          orderBy: 'modifiedTime desc',
+          // Drive rejects `orderBy` when `q` contains a `fullText` clause
+          // ("Sorting is not supported for queries with fullText terms") —
+          // only the "name" search mode avoids fullText.
+          ...(args.searchIn === 'name' ? { orderBy: 'modifiedTime desc' } : {}),
           fields: 'files(id,name,modifiedTime,createdTime,webViewLink,owners(displayName),parents)',
           supportsAllDrives: true,
           includeItemsFromAllDrives: true,

--- a/src/tools/sheets/listGoogleSheets.ts
+++ b/src/tools/sheets/listGoogleSheets.ts
@@ -44,7 +44,9 @@ export function register(server: FastMCP) {
         const response = await drive.files.list({
           q: queryString,
           pageSize: args.maxResults,
-          orderBy: args.orderBy === 'name' ? 'name' : args.orderBy,
+          // Drive rejects `orderBy` when `q` contains a `fullText` clause
+          // ("Sorting is not supported for queries with fullText terms").
+          ...(args.query ? {} : { orderBy: args.orderBy === 'name' ? 'name' : args.orderBy }),
           fields:
             'files(id,name,modifiedTime,createdTime,size,webViewLink,owners(displayName,emailAddress))',
           supportsAllDrives: true,


### PR DESCRIPTION
## Summary
- `drive.files.list` rejects `orderBy` whenever `q` contains a `fullText` clause, returning a 403 ("Sorting is not supported for queries with fullText terms") that the tools' catch-all handler maps to a misleading "Permission denied, grant Drive access" message.
- Omits `orderBy` in exactly that case in `listGoogleSheets`, `listGoogleDocs`, `searchDriveFiles`, and `searchGoogleDocs` — audited all four Drive-query builders for the same pattern per the note in #155.

Fixes #155.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/tools/sheets/listGoogleSheets.test.ts src/tools/drive` — all pass except one pre-existing, unrelated Windows-path test failure in `downloadFile.test.ts` (confirmed present on `main` before this change too)
- [x] Manually reproduced and fixed the 403 locally against a live Drive account while debugging #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)